### PR TITLE
refactor: pass feature configs through props

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,13 @@
 import Section from './components/Section.jsx';
 import News from './features/News/News.jsx';
 import Schedule from './features/Schedule/Schedule.jsx';
+import newsConfig from './features/News/config.json';
+import scheduleConfig from './features/Schedule/config.json';
 
 const App = () => {
   const sections = [
-    { id: 'news', title: 'Latest News', component: <News /> },
-    { id: 'schedule', title: 'Upcoming Schedule', component: <Schedule /> },
+    { id: 'news', title: 'Latest News', component: <News data={newsConfig} /> },
+    { id: 'schedule', title: 'Upcoming Schedule', component: <Schedule data={scheduleConfig} /> },
   ];
 
   return (

--- a/src/components/Section.jsx
+++ b/src/components/Section.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 const Section = ({ title, children }) => (
   <section className="section">
     <div className="section__header">
@@ -6,5 +8,10 @@ const Section = ({ title, children }) => (
     <div className="section__content">{children}</div>
   </section>
 );
+
+Section.propTypes = {
+  title: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
 
 export default Section;

--- a/src/features/News/News.jsx
+++ b/src/features/News/News.jsx
@@ -1,10 +1,10 @@
-import config from './config.json';
+import PropTypes from 'prop-types';
 
-const News = () => (
+const News = ({ data }) => (
   <div className="news">
-    <h3 className="news__headline">{config.headline}</h3>
+    <h3 className="news__headline">{data.headline}</h3>
     <ul className="news__list">
-      {config.articles.map((article) => (
+      {data.articles.map((article) => (
         <li key={article.id} className="news__item">
           <article>
             <h4 className="news__title">{article.title}</h4>
@@ -18,5 +18,19 @@ const News = () => (
     </ul>
   </div>
 );
+
+News.propTypes = {
+  data: PropTypes.shape({
+    headline: PropTypes.string.isRequired,
+    articles: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+        title: PropTypes.string.isRequired,
+        summary: PropTypes.string.isRequired,
+        url: PropTypes.string.isRequired,
+      }),
+    ).isRequired,
+  }).isRequired,
+};
 
 export default News;

--- a/src/features/Schedule/Schedule.jsx
+++ b/src/features/Schedule/Schedule.jsx
@@ -1,10 +1,10 @@
-import config from './config.json';
+import PropTypes from 'prop-types';
 
-const Schedule = () => (
+const Schedule = ({ data }) => (
   <div className="schedule">
-    <p className="schedule__description">{config.description}</p>
+    <p className="schedule__description">{data.description}</p>
     <ul className="schedule__list">
-      {config.items.map((item) => (
+      {data.items.map((item) => (
         <li key={item.id} className="schedule__item">
           <time className="schedule__time" dateTime={item.isoDate}>
             {item.date}
@@ -18,5 +18,20 @@ const Schedule = () => (
     </ul>
   </div>
 );
+
+Schedule.propTypes = {
+  data: PropTypes.shape({
+    description: PropTypes.string.isRequired,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+        isoDate: PropTypes.string.isRequired,
+        date: PropTypes.string.isRequired,
+        title: PropTypes.string.isRequired,
+        location: PropTypes.string.isRequired,
+      }),
+    ).isRequired,
+  }).isRequired,
+};
 
 export default Schedule;


### PR DESCRIPTION
## Summary
- pass the news and schedule configurations from App and consume them via props
- add PropTypes validation for feature sections and shared Section component

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f60e22846c832384e8a117f5b818e2