### PR TITLE
feat: update hero figures layout

### DIFF
--- a/src/assets/hero/cs2-operator.svg
+++ b/src/assets/hero/cs2-operator.svg
@@ -1,0 +1,15 @@
+<svg width="580" height="720" viewBox="0 0 580 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="580" height="720" rx="280" fill="url(#paint0_linear)"/>
+  <path d="M280 80C221 80 175 126 175 185C175 230 205 272 247 286L222 400H166C144 400 126 418 126 440C126 461 143 478 165 480L204 485L177 612C172 634 187 655 209 659C220 661 231 657 240 650L298 602L346 650C364 667 393 662 405 641C409 634 411 625 409 616L382 485L417 480C439 477 456 459 456 438C456 417 439 400 418 400H361L334 286C374 272 404 232 404 186C404 126 358 80 300 80H280Z" fill="url(#paint1_linear)" opacity="0.9"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="580" y1="720" x2="-20" y2="-40" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#112B58"/>
+      <stop offset="1" stop-color="#2F4BFF"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="118" y1="690" x2="516" y2="126" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#5AF0FF" stop-opacity="0.95"/>
+      <stop offset="0.45" stop-color="#67A4FF" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#1C237D" stop-opacity="0.95"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/hero/dota-guardian.svg
+++ b/src/assets/hero/dota-guardian.svg
@@ -1,0 +1,15 @@
+<svg width="580" height="720" viewBox="0 0 580 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="580" height="720" rx="280" fill="url(#paint0_linear)"/>
+  <path d="M307 90C259 90 215 118 194 162C172 209 182 267 221 303L188 340C164 364 160 400 179 426L215 475L169 518C147 539 149 574 172 593C186 604 205 607 221 602L270 587L278 618C283 639 304 653 325 649C332 648 339 646 345 642L403 605L435 643C453 665 487 666 507 646C525 628 526 598 510 577L470 526L517 472C540 445 535 404 507 383L461 348L495 305C533 257 528 190 485 150C455 122 410 107 367 116L307 90Z" fill="url(#paint1_linear)" opacity="0.92"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="562" y1="695" x2="44" y2="40" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#441445"/>
+      <stop offset="1" stop-color="#FF536C"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="138" y1="696" x2="547" y2="131" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFAE4A" stop-opacity="0.95"/>
+      <stop offset="0.45" stop-color="#FF5F6D" stop-opacity="0.9"/>
+      <stop offset="1" stop-color="#611A66" stop-opacity="0.95"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/assets/hero/hero-backdrop.svg
+++ b/src/assets/hero/hero-backdrop.svg
@@ -1,0 +1,26 @@
+<svg width="900" height="720" viewBox="0 0 900 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="heroBackdropGradient" x1="870" y1="700" x2="120" y2="40" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#110C2F"/>
+      <stop offset="0.45" stop-color="#1C1445"/>
+      <stop offset="1" stop-color="#2C1A69"/>
+    </linearGradient>
+    <radialGradient id="heroBackdropGlow" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 320 -420 0 450 260)">
+      <stop offset="0" stop-color="#814BFF" stop-opacity="0.95"/>
+      <stop offset="0.4" stop-color="#4B2FE3" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#120826" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="heroBackdropStroke" x1="0" y1="0" x2="900" y2="720" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FF8A65" stop-opacity="0.75"/>
+      <stop offset="0.5" stop-color="#FF4E7A" stop-opacity="0.3"/>
+      <stop offset="1" stop-color="#3AA0FF" stop-opacity="0.7"/>
+    </linearGradient>
+  </defs>
+  <rect width="900" height="720" rx="180" fill="url(#heroBackdropGradient)"/>
+  <path d="M60 524C179 429 324 418 458 468C608 525 704 421 812 332C848 303 884 274 900 266V720H0V604C17 595 43 553 60 524Z" fill="url(#heroBackdropGlow)"/>
+  <path d="M72 470C197 356 373 360 503 410C653 468 742 399 840 318C861 301 888 275 900 264" stroke="url(#heroBackdropStroke)" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" opacity="0.65"/>
+  <path d="M120 140C164 104 220 82 270 98C356 126 416 224 513 236C581 244 640 202 702 175C758 151 816 144 864 164C884 172 900 182 900 182V0H0V248C14 226 54 193 120 140Z" fill="#1A123B" opacity="0.72"/>
+  <circle cx="168" cy="162" r="5" fill="#FF886C" opacity="0.65"/>
+  <circle cx="742" cy="128" r="8" fill="#5AF0FF" opacity="0.65"/>
+  <circle cx="620" cy="564" r="6" fill="#F9F871" opacity="0.55"/>
+</svg>

--- a/src/assets/hero/phoenix-avatar.svg
+++ b/src/assets/hero/phoenix-avatar.svg
@@ -1,0 +1,22 @@
+<svg width="620" height="720" viewBox="0 0 620 720" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="phoenixBase" x1="590" y1="700" x2="80" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#140018"/>
+      <stop offset="0.35" stop-color="#2E0239"/>
+      <stop offset="1" stop-color="#50126C"/>
+    </linearGradient>
+    <linearGradient id="phoenixFeathers" x1="160" y1="700" x2="520" y2="100" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFAA4B" stop-opacity="0.98"/>
+      <stop offset="0.4" stop-color="#FF4D6D" stop-opacity="0.92"/>
+      <stop offset="1" stop-color="#6622FF" stop-opacity="0.95"/>
+    </linearGradient>
+    <radialGradient id="phoenixEye" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0 16 -16 0 396 218)">
+      <stop offset="0" stop-color="#FFE066"/>
+      <stop offset="1" stop-color="#FF4D6D" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="620" height="720" rx="260" fill="url(#phoenixBase)"/>
+  <path d="M314 120C260 118 212 144 182 196C147 258 164 340 222 386L182 426C154 454 158 498 188 524L244 572L208 610C186 633 190 670 216 686C232 696 252 696 268 686L336 640L402 684C427 700 460 692 476 668C485 656 486 640 480 626L454 564L520 508C550 484 556 440 534 408L480 332L526 280C566 234 560 160 514 122C472 86 402 122 358 128L314 120Z" fill="url(#phoenixFeathers)" opacity="0.94"/>
+  <path d="M374 210C386 210 396 220 396 232C396 244 386 254 374 254C362 254 352 244 352 232C352 220 362 210 374 210Z" fill="url(#phoenixEye)"/>
+  <path d="M166 288C146 240 150 176 180 130C218 74 284 42 350 50C418 58 486 104 516 170C540 222 534 290 498 338" stroke="#FFB347" stroke-width="18" stroke-linecap="round" stroke-opacity="0.35"/>
+</svg>

--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -1,22 +1,106 @@
 import PropTypes from 'prop-types';
+import heroBackdrop from '../../assets/hero/hero-backdrop.svg';
+import cs2Operator from '../../assets/hero/cs2-operator.svg';
+import phoenixAvatar from '../../assets/hero/phoenix-avatar.svg';
+
+const figureImages = {
+  backdrop: heroBackdrop,
+  cs2: cs2Operator,
+  operator: cs2Operator,
+  dota: phoenixAvatar,
+  phoenix: phoenixAvatar,
+};
 
 const Hero = ({ data }) => {
-  const { tagline, title, subtitle, season, action } = data;
+  const { badge, title, subtitle, tabs, panels, meta, partners, figures } = data;
+
+  const figureConfig = [
+    ['backdrop', figures?.backdrop],
+    ['left', figures?.left],
+    ['center', figures?.center],
+    ['right', figures?.right],
+  ].filter(([, value]) => value?.key && figureImages[value.key]);
+
   return (
     <div className="hero">
-      <span className="hero__tagline">{tagline}</span>
-      <h1 className="hero__title">{title}</h1>
-      <p className="hero__subtitle">{subtitle}</p>
-      <div className="hero__meta">
-        <span className="hero__season">{season.label}</span>
-        <span className="hero__dates">{season.dates}</span>
-        <span className="hero__location">{season.location}</span>
-      </div>
-      <div className="hero__actions">
-        <a className="hero__cta" href={action.href}>
-          {action.label}
-        </a>
-        <span className="hero__note">{action.note}</span>
+      <div className="hero__gradient hero__gradient--left" aria-hidden="true" />
+      <div className="hero__gradient hero__gradient--right" aria-hidden="true" />
+
+      {figureConfig.map(([position, value]) => (
+        <div key={position} className={`hero__figure hero__figure--${position}`}>
+          <img src={figureImages[value.key]} alt={value.alt} loading="lazy" />
+        </div>
+      ))}
+
+      <div className="hero__body">
+        <span className="hero__badge">{badge}</span>
+
+        <h1 className="hero__title" aria-label={`${title.left} ${title.accent} ${title.right}`}>
+          <span className="hero__title-part hero__title-part--left">{title.left}</span>
+          <span className="hero__title-accent">{title.accent}</span>
+          <span className="hero__title-part hero__title-part--right">{title.right}</span>
+        </h1>
+
+        <p className="hero__subtitle">{subtitle}</p>
+
+        {tabs?.length ? (
+          <nav className="hero__tabs" aria-label="Дисциплины сезона">
+            <ul>
+              {tabs.map((tab) => (
+                <li key={tab.label}>
+                  <a
+                    className={`hero__tab ${tab.active ? 'hero__tab--active' : ''}`.trim()}
+                    href={tab.href}
+                    aria-current={tab.active ? 'page' : undefined}
+                  >
+                    {tab.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        ) : null}
+
+        <div className="hero__panels" role="list">
+          {panels.map((panel) => (
+            <article key={panel.id} className="hero__panel" role="listitem">
+              <header className="hero__panel-header">
+                <h2 className="hero__panel-title">{panel.title}</h2>
+                <p className="hero__panel-description">{panel.description}</p>
+              </header>
+              <div className="hero__panel-actions">
+                <a className="hero__panel-action hero__panel-action--primary" href={panel.primaryAction.href}>
+                  {panel.primaryAction.label}
+                </a>
+                <a className="hero__panel-action hero__panel-action--ghost" href={panel.secondaryAction.href}>
+                  {panel.secondaryAction.label}
+                </a>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="hero__divider" aria-hidden="true" />
+
+        <div className="hero__footer">
+          <div className="hero__metric">
+            <span className="hero__metric-label">{meta.prize.label}</span>
+            <span className="hero__metric-value">{meta.prize.value}</span>
+          </div>
+          <div className="hero__timer">
+            <span className="hero__metric-label">{meta.timer.label}</span>
+            <span className="hero__timer-value">{meta.timer.value}</span>
+          </div>
+          {partners?.length ? (
+            <div className="hero__partners" aria-label="Партнёры сезона">
+              {partners.map((partner) => (
+                <a key={partner.href} className="hero__partner" href={partner.href}>
+                  {partner.label}
+                </a>
+              ))}
+            </div>
+          ) : null}
+        </div>
       </div>
     </div>
   );
@@ -24,19 +108,69 @@ const Hero = ({ data }) => {
 
 Hero.propTypes = {
   data: PropTypes.shape({
-    tagline: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
+    badge: PropTypes.string.isRequired,
+    title: PropTypes.shape({
+      left: PropTypes.string.isRequired,
+      accent: PropTypes.string.isRequired,
+      right: PropTypes.string.isRequired,
+    }).isRequired,
     subtitle: PropTypes.string.isRequired,
-    season: PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      dates: PropTypes.string.isRequired,
-      location: PropTypes.string.isRequired,
+    tabs: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        href: PropTypes.string.isRequired,
+        active: PropTypes.bool,
+      })
+    ),
+    panels: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        title: PropTypes.string.isRequired,
+        description: PropTypes.string.isRequired,
+        primaryAction: PropTypes.shape({
+          label: PropTypes.string.isRequired,
+          href: PropTypes.string.isRequired,
+        }).isRequired,
+        secondaryAction: PropTypes.shape({
+          label: PropTypes.string.isRequired,
+          href: PropTypes.string.isRequired,
+        }).isRequired,
+      })
+    ).isRequired,
+    meta: PropTypes.shape({
+      prize: PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        value: PropTypes.string.isRequired,
+      }).isRequired,
+      timer: PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        value: PropTypes.string.isRequired,
+      }).isRequired,
     }).isRequired,
-    action: PropTypes.shape({
-      label: PropTypes.string.isRequired,
-      href: PropTypes.string.isRequired,
-      note: PropTypes.string,
-    }).isRequired,
+    partners: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        href: PropTypes.string.isRequired,
+      })
+    ),
+    figures: PropTypes.shape({
+      backdrop: PropTypes.shape({
+        key: PropTypes.oneOf(Object.keys(figureImages)).isRequired,
+        alt: PropTypes.string.isRequired,
+      }),
+      left: PropTypes.shape({
+        key: PropTypes.oneOf(Object.keys(figureImages)).isRequired,
+        alt: PropTypes.string.isRequired,
+      }),
+      center: PropTypes.shape({
+        key: PropTypes.oneOf(Object.keys(figureImages)).isRequired,
+        alt: PropTypes.string.isRequired,
+      }),
+      right: PropTypes.shape({
+        key: PropTypes.oneOf(Object.keys(figureImages)).isRequired,
+        alt: PropTypes.string.isRequired,
+      }),
+    }),
   }).isRequired,
 };
 

--- a/src/features/Hero/config.json
+++ b/src/features/Hero/config.json
@@ -1,15 +1,87 @@
 {
-  "tagline": "YarCyberSeason",
-  "title": "Кибербезопасность начинается здесь",
-  "subtitle": "Фестиваль экспериментов, практики и соревновательной аналитики для специалистов по информационной безопасности.",
-  "season": {
-    "label": "Сезон 2024",
-    "dates": "1 сентября — 30 ноября",
-    "location": "Ярославль + онлайн"
+  "badge": "YCS Cup",
+  "title": {
+    "left": "CS2",
+    "accent": "vs",
+    "right": "Dota 2"
   },
-  "action": {
-    "label": "Стать участником",
-    "href": "https://yarcyberseason.ru/register",
-    "note": "Регистрация открыта до 15 августа"
+  "subtitle": "Квалификации стартуют",
+  "tabs": [
+    {
+      "label": "CS2",
+      "href": "#cs2",
+      "active": true
+    },
+    {
+      "label": "Dota 2",
+      "href": "#dota2",
+      "active": false
+    }
+  ],
+  "panels": [
+    {
+      "id": "cs2",
+      "title": "Квалификация CS2",
+      "description": "Командный формат 5x5. Онлайн-отборы и LAN-финал в Ярославле.",
+      "primaryAction": {
+        "label": "Регистрация",
+        "href": "https://yarcyberseason.ru/cs2"
+      },
+      "secondaryAction": {
+        "label": "Регламент",
+        "href": "https://yarcyberseason.ru/rules/cs2"
+      }
+    },
+    {
+      "id": "dota2",
+      "title": "Квалификация Dota 2",
+      "description": "Захватывающие серии best-of-3. Лучшие команды проходят в плей-офф.",
+      "primaryAction": {
+        "label": "Регистрация",
+        "href": "https://yarcyberseason.ru/dota2"
+      },
+      "secondaryAction": {
+        "label": "Регламент",
+        "href": "https://yarcyberseason.ru/rules/dota2"
+      }
+    }
+  ],
+  "meta": {
+    "prize": {
+      "label": "Призовой фонд",
+      "value": "1 200 000 ₽"
+    },
+    "timer": {
+      "label": "До старта трансляции",
+      "value": "00:00:00"
+    }
+  },
+  "partners": [
+    {
+      "label": "Logo",
+      "href": "https://yarcyberseason.ru/partners/ycs"
+    },
+    {
+      "label": "Logo",
+      "href": "https://yarcyberseason.ru/partners/tech"
+    },
+    {
+      "label": "Logo",
+      "href": "https://yarcyberseason.ru/partners/esports"
+    }
+  ],
+  "figures": {
+    "backdrop": {
+      "key": "backdrop",
+      "alt": "Вырезать фон 900×720 с закруглёнными углами, оставить мягкий верхний градиент и нижнюю неоновую волну, сохранить прозрачность углов"
+    },
+    "left": {
+      "key": "phoenix",
+      "alt": "Вырезать феникса с клювом и крыльями целиком, уложить в прямоугольник 620×720, фон удалить до прозрачности, оставить внутреннее свечение перьев"
+    },
+    "center": {
+      "key": "operator",
+      "alt": "Вырезать бойца CS2 по овальному силуэту, оставить шлем и плечи на переднем плане, экспортировать с мягкой тенью и прозрачным фоном"
+    }
   }
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -81,15 +81,25 @@ main.app {
 }
 
 .section--hero {
+  position: relative;
   padding: 0;
   overflow: hidden;
-  background: radial-gradient(circle at top left, rgba(96, 165, 250, 0.35), transparent 55%),
-    linear-gradient(135deg, #0f172a, #111827);
-  color: #f8fafc;
+  background: radial-gradient(circle at 20% 20%, rgba(96, 165, 250, 0.4), transparent 55%),
+    radial-gradient(circle at 80% 20%, rgba(236, 72, 153, 0.35), transparent 55%),
+    linear-gradient(135deg, #07091e, #1a0f31 55%, #220d38);
+  color: #fdf2ff;
+}
+
+.section--hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.08), transparent 60%);
 }
 
 .section--hero .section__content {
-  padding: 3.5rem 3rem;
+  padding: 0;
 }
 
 .section__header {
@@ -106,68 +116,461 @@ main.app {
 }
 
 .hero {
-  max-width: 720px;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  padding: 4rem 3rem 3.5rem;
+  min-height: 540px;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.hero__gradient {
+  position: absolute;
+  width: 480px;
+  height: 480px;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.75;
+  z-index: 0;
+}
+
+.hero__gradient--left {
+  background: rgba(96, 165, 250, 0.35);
+  top: 10%;
+  left: -15%;
+}
+
+.hero__gradient--right {
+  background: rgba(236, 72, 153, 0.35);
+  top: 5%;
+  right: -15%;
+}
+
+.hero__figure {
+  position: absolute;
+  pointer-events: none;
+}
+
+.hero__figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.hero__figure--backdrop {
+  top: clamp(-10rem, -16vw, -7rem);
+  left: 50%;
+  width: min(940px, 120vw);
+  transform: translateX(-50%);
+  z-index: 0;
+}
+
+.hero__figure--backdrop img {
+  filter: drop-shadow(0 60px 120px rgba(34, 16, 71, 0.55));
+}
+
+.hero__figure--left {
+  bottom: clamp(-3rem, -4vw, -1.5rem);
+  left: clamp(-2rem, -5vw, -3.25rem);
+  width: clamp(260px, 32vw, 340px);
+  z-index: 2;
+}
+
+.hero__figure--center {
+  bottom: clamp(-5rem, -6vw, -2rem);
+  left: 50%;
+  width: clamp(280px, 36vw, 360px);
+  transform: translateX(-50%);
+  z-index: 3;
+}
+
+.hero__figure--right {
+  bottom: clamp(-3rem, -4vw, -1.5rem);
+  right: clamp(-2rem, -5vw, -3.25rem);
+  width: clamp(260px, 32vw, 340px);
+  z-index: 2;
+}
+
+.hero__figure:not(.hero__figure--backdrop) img {
+  filter: drop-shadow(0 30px 60px rgba(0, 0, 0, 0.45));
+}
+
+.hero__body {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+  text-align: center;
+  width: min(100%, 900px);
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 1.4rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.4), rgba(236, 72, 153, 0.4));
+  color: rgba(255, 255, 255, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.2);
+}
+
+.hero__title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: clamp(2.8rem, 4vw + 1.2rem, 4.25rem);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.hero__title-part--left {
+  color: #7dd3fc;
+}
+
+.hero__title-accent {
+  padding: 0 1.25rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #fbbf24, #f97316);
+  color: #0b0b1c;
+  font-size: 0.6em;
+  font-weight: 800;
+  letter-spacing: 0.3em;
+}
+
+.hero__title-part--right {
+  color: #f9a8d4;
+}
+
+.hero__subtitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: rgba(244, 244, 255, 0.85);
+}
+
+.hero__tabs ul {
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.hero__tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 120px;
+  padding: 0.65rem 1.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.hero__tab:hover,
+.hero__tab:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.hero__tab--active {
+  background: linear-gradient(135deg, #22d3ee, #a855f7);
+  color: #0c1027;
+  font-weight: 700;
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.4);
+}
+
+.hero__panels {
+  display: grid;
+  gap: 1.25rem;
+  width: 100%;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.hero__panel {
+  position: relative;
+  padding: 1.75rem;
+  border-radius: 1.5rem;
+  background: rgba(14, 20, 43, 0.75);
+  border: 1px solid rgba(148, 163, 255, 0.2);
+  backdrop-filter: blur(22px);
+  -webkit-backdrop-filter: blur(22px);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
 }
 
-.hero__tagline {
-  font-size: 0.9rem;
-  letter-spacing: 0.24em;
+.hero__panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(236, 72, 153, 0.15));
+  opacity: 0.85;
+}
+
+.hero__panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero__panel-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hero__panel-title {
+  margin: 0;
+  font-size: 1.25rem;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.85);
+  letter-spacing: 0.14em;
+  color: rgba(255, 255, 255, 0.92);
 }
 
-.hero__title {
+.hero__panel-description {
   margin: 0;
-  font-size: 3rem;
-  line-height: 1.05;
+  color: rgba(226, 232, 255, 0.72);
 }
 
-.hero__subtitle {
-  margin: 0;
-  font-size: 1.125rem;
-  color: rgba(226, 232, 240, 0.9);
+.hero__panel-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
 }
 
-.hero__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-  font-weight: 600;
-  color: rgba(226, 232, 240, 0.85);
-}
-
-.hero__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem 1.5rem;
-  align-items: center;
-}
-
-.hero__cta {
+.hero__panel-action {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.85rem 1.6rem;
-  background: linear-gradient(135deg, #60a5fa, #a855f7);
-  color: #0f172a;
-  border-radius: 0.9rem;
-  font-weight: 700;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
   text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 16px 30px rgba(96, 165, 250, 0.35);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
 }
 
-.hero__cta:hover,
-.hero__cta:focus {
-  transform: translateY(-2px);
-  box-shadow: 0 20px 38px rgba(148, 163, 184, 0.35);
+.hero__panel-action--primary {
+  background: linear-gradient(135deg, #22d3ee, #818cf8);
+  color: #080817;
+  box-shadow: 0 14px 30px rgba(96, 165, 250, 0.45);
 }
 
-.hero__note {
-  color: rgba(226, 232, 240, 0.7);
+.hero__panel-action--primary:hover,
+.hero__panel-action--primary:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 38px rgba(96, 165, 250, 0.5);
+}
+
+.hero__panel-action--ghost {
+  background: rgba(15, 23, 42, 0.55);
+  color: rgba(229, 231, 255, 0.85);
+  border: 1px solid rgba(148, 163, 255, 0.35);
+}
+
+.hero__panel-action--ghost:hover,
+.hero__panel-action--ghost:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(15, 23, 42, 0.75);
+  border-color: rgba(255, 255, 255, 0.45);
+}
+
+.hero__divider {
+  width: 100%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.35), transparent);
+}
+
+.hero__footer {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  width: 100%;
+  gap: 1.5rem;
+}
+
+.hero__metric,
+.hero__timer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  text-align: left;
+}
+
+.hero__metric-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 255, 0.55);
+}
+
+.hero__metric-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.hero__timer-value {
+  font-family: 'Orbitron', 'Inter', sans-serif;
+  font-size: 2rem;
+  letter-spacing: 0.16em;
+  color: #facc15;
+  text-align: center;
+}
+
+.hero__partners {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.hero__partner {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 88px;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: rgba(15, 23, 42, 0.85);
+  background: rgba(255, 255, 255, 0.9);
+  text-decoration: none;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.25);
+}
+
+.hero__partner:hover,
+.hero__partner:focus-visible {
+  background: #ffffff;
+  transform: translateY(-1px);
+}
+
+@media (max-width: 960px) {
+  .hero {
+    padding: 3.5rem 2.5rem 3rem;
+  }
+
+  .hero__figure--backdrop {
+    top: clamp(-8rem, -14vw, -6rem);
+    width: min(820px, 140vw);
+  }
+
+  .hero__figure--left,
+  .hero__figure--right {
+    width: clamp(220px, 44vw, 280px);
+  }
+
+  .hero__figure--left {
+    left: clamp(-1.5rem, -5vw, -2.5rem);
+  }
+
+  .hero__figure--right {
+    right: clamp(-1.5rem, -5vw, -2.5rem);
+  }
+
+  .hero__figure--center {
+    width: clamp(260px, 48vw, 320px);
+    bottom: clamp(-4rem, -6vw, -2.5rem);
+  }
+
+  .hero__footer {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero__partners {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 3rem 1.5rem 2.75rem;
+    min-height: 100%;
+  }
+
+  .hero__figure--backdrop {
+    top: clamp(-6rem, -10vw, -4rem);
+    width: min(720px, 150vw);
+  }
+
+  .hero__figure--left,
+  .hero__figure--right {
+    width: clamp(200px, 42vw, 250px);
+  }
+
+  .hero__figure--left {
+    left: clamp(-0.75rem, -3vw, -1.25rem);
+  }
+
+  .hero__figure--right {
+    right: clamp(-0.75rem, -3vw, -1.25rem);
+  }
+
+  .hero__figure--center {
+    width: clamp(240px, 54vw, 300px);
+    bottom: clamp(-3.5rem, -5vw, -1.75rem);
+  }
+
+  .hero__body {
+    align-items: stretch;
+    text-align: left;
+  }
+
+  .hero__title {
+    justify-content: flex-start;
+  }
+
+  .hero__tabs ul {
+    grid-auto-flow: row;
+    justify-items: start;
+  }
+
+  .hero__panels {
+    grid-template-columns: 1fr;
+  }
+
+  .hero__footer {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+
+  .hero__metric,
+  .hero__timer {
+    text-align: left;
+  }
+
+  .hero__partners {
+    justify-content: flex-start;
+  }
+
+  .hero__figure--left,
+  .hero__figure--right {
+    display: none;
+  }
+
+  .hero__figure--center {
+    width: min(280px, 68vw);
+  }
+
+  .hero__figure--backdrop {
+    width: min(540px, 180vw);
+  }
 }
 
 .benefits {


### PR DESCRIPTION
## Summary
- add backdrop and phoenix assets to drive the three-image hero composition
- render hero figures from configuration for backdrop, left, center, and right slots with updated alt slicing notes
- tune hero positioning styles for the new layout across desktop and mobile breakpoints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f683eea58083239ae933ffdf2155e8