### PR TITLE
feat: redesign hero into versus showdown

### DIFF
--- a/src/features/Hero/config.json
+++ b/src/features/Hero/config.json
@@ -1,59 +1,68 @@
 {
-  "tagline": "YarCyberSeason",
-  "title": "Кибербезопасность начинается здесь",
-  "subtitle": "Фестиваль экспериментов, практики и соревновательной аналитики для специалистов по информационной безопасности.",
-  "season": {
-    "label": "Сезон 2024",
-    "dates": "1 сентября — 30 ноября",
-    "location": "Ярославль + онлайн"
+  "branding": {
+    "tagline": "YCS CUP",
+    "label": "YarCyberSeason",
+    "links": [
+      { "label": "Формат", "href": "#format" },
+      { "label": "Правила", "href": "#rules" },
+      { "label": "Партнеры", "href": "#partners" }
+    ]
   },
-  "media": {
-    "src": "https://cdn.yarcyberseason.ru/media/hero-loop.mp4",
-    "type": "video/mp4",
-    "poster": "https://cdn.yarcyberseason.ru/media/hero-poster.jpg",
-    "mobilePoster": "https://cdn.yarcyberseason.ru/media/hero-poster-mobile.jpg",
-    "alt": "Команда участников YarCyberSeason на арене турнира",
-    "disableOnMobile": true
+  "title": "CS2 vs Dota 2",
+  "subtitle": "Квалификации стартуют",
+  "background": {
+    "left": "https://images.unsplash.com/photo-1618005198919-d3d4b5a92eee?auto=format&fit=crop&w=900&q=80",
+    "right": "https://images.unsplash.com/photo-1618005198878-1fd66f39e7bb?auto=format&fit=crop&w=900&q=80"
   },
-  "facts": [
+  "match": {
+    "left": {
+      "code": "CS2",
+      "name": "Counter-Strike 2",
+      "note": "Best of 3, 5×5"
+    },
+    "right": {
+      "code": "Dota 2",
+      "name": "Defense of the Ancients",
+      "note": "Captain's Mode, 5×5"
+    }
+  },
+  "tabs": [
+    { "label": "CS2", "href": "#qual-cs2" },
+    { "label": "Dota 2", "href": "#qual-dota" }
+  ],
+  "qualifiers": [
     {
-      "title": "5 игровых форматов",
-      "description": "CTF, reverse, threat hunting, форензика и live-аналитика",
-      "icon": "🎯"
+      "tag": "CS2",
+      "title": "Квалификация CS2",
+      "description": "Онлайн-раунды, 24 октября, 19:00 МСК",
+      "cta": {
+        "label": "Регистрация",
+        "href": "https://yarcyberseason.ru/register/cs2"
+      }
     },
     {
-      "title": "24/7 практика",
-      "description": "Лаборатория открыта круглосуточно с менторской поддержкой",
-      "icon": "🛡️"
-    },
-    {
-      "title": "Pro-комьюнити",
-      "description": "Эксперты из SOC, инцидент-реагирования и синего тиминга",
-      "icon": "🤝"
-    },
-    {
-      "title": "Гибридный формат",
-      "description": "Оффлайн в Ярославле и онлайн из любой точки мира",
-      "icon": "🌐"
+      "tag": "Dota 2",
+      "title": "Квалификация Dota 2",
+      "description": "LAN-финал, 27 октября, 12:00 МСК",
+      "cta": {
+        "label": "Принять участие",
+        "href": "https://yarcyberseason.ru/register/dota2"
+      }
     }
   ],
-  "primaryCta": {
-    "label": "Стать участником",
-    "href": "https://yarcyberseason.ru/register",
-    "note": "Регистрация открыта до 15 августа",
-    "icon": "🚀",
-    "ariaLabel": "Стать участником YarCyberSeason"
-  },
-  "secondaryCta": {
-    "label": "Скачать гайд",
-    "href": "https://yarcyberseason.ru/media/YCS-guide.pdf",
-    "icon": "📄",
-    "ariaLabel": "Скачать гайд участника"
+  "prize": {
+    "label": "Призовой фонд",
+    "value": "500 000 ₽"
   },
   "timer": {
-    "label": "До закрытия регистрации",
-    "deadline": "2024-08-15T20:59:59+03:00",
-    "expiredLabel": "Регистрация закрыта",
-    "fallbackLabel": "Следите за обновлениями"
-  }
+    "label": "До старта квалификации",
+    "deadline": "2024-10-24T19:00:00+03:00",
+    "expiredLabel": "Квалификация началась",
+    "fallbackLabel": "Следите за расписанием"
+  },
+  "logos": [
+    "YCS",
+    "CS2",
+    "Dota 2"
+  ]
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -166,59 +166,47 @@ main.app {
 .section--hero {
   padding: 0;
   overflow: hidden;
-  background: linear-gradient(135deg, #0b1120, #111827);
-  color: #f8fafc;
+  background: radial-gradient(circle at 10% 10%, rgba(120, 64, 255, 0.45), transparent 50%),
+      radial-gradient(circle at 90% 20%, rgba(255, 100, 171, 0.35), transparent 55%),
+    linear-gradient(160deg, #080422, #1a0f3f);
+  color: #f8f9ff;
 }
 
 .section--hero .section__content {
   padding: 0;
 }
 
-.section__header {
-  margin-bottom: 1rem;
-}
-
-.section__title {
-  margin: 0;
-  font-size: 1.5rem;
-}
-
-.section--hero .section__title {
-  color: inherit;
-}
-
 .hero {
   position: relative;
-  min-height: clamp(28rem, 60vh, 44rem);
+  min-height: clamp(32rem, 72vh, 48rem);
   display: flex;
   align-items: stretch;
   color: inherit;
+  border-radius: inherit;
+  overflow: hidden;
 }
 
 .hero__background {
   position: absolute;
   inset: 0;
   z-index: 0;
-  overflow: hidden;
-  background: radial-gradient(circle at 20% 20%, rgba(96, 165, 250, 0.25), transparent 55%),
-    #020617;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  opacity: 0.4;
 }
 
-.hero__video,
-.hero__poster {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
+.hero__background-layer {
+  background-size: cover;
+  background-position: center;
+  filter: saturate(1.15) contrast(1.05);
 }
 
-.hero__video {
-  filter: saturate(1.1) contrast(1.05);
-  transform: scale(1.02);
+.hero__background-layer--left {
+  mix-blend-mode: screen;
 }
 
-.hero__poster {
-  filter: brightness(0.9) saturate(1.05);
+.hero__background-layer--right {
+  mix-blend-mode: lighten;
 }
 
 .hero__overlay {
@@ -226,255 +214,414 @@ main.app {
   inset: 0;
   z-index: 1;
   pointer-events: none;
-  background: linear-gradient(115deg, rgba(15, 23, 42, 0.88), rgba(30, 64, 175, 0.3) 55%, rgba(15, 23, 42, 0.95)),
-    radial-gradient(circle at top left, rgba(96, 165, 250, 0.45), transparent 60%);
+  background:
+    radial-gradient(circle at 20% 50%, rgba(120, 64, 255, 0.6), transparent 55%),
+    radial-gradient(circle at 80% 35%, rgba(255, 114, 94, 0.55), transparent 60%),
+    linear-gradient(120deg, rgba(8, 4, 34, 0.9), rgba(17, 22, 57, 0.9));
 }
 
 .hero__inner {
   position: relative;
   z-index: 2;
-  display: grid;
-  gap: clamp(1.5rem, 2vw, 2.5rem);
-  grid-template-columns: minmax(0, 1fr);
   width: 100%;
-  padding: clamp(2.5rem, 6vw, 4rem) clamp(1.5rem, 5vw, 3.5rem);
+  padding: clamp(2.5rem, 6vw, 4.5rem) clamp(1.5rem, 6vw, 4rem);
 }
 
-.hero__content {
-  max-width: min(720px, 100%);
+.hero__inner--versus {
   display: flex;
   flex-direction: column;
-  gap: clamp(1rem, 2vw, 1.75rem);
+  gap: clamp(1.75rem, 3vw, 2.75rem);
+}
+
+.hero__topbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+}
+
+.hero__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.hero__brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, #7c3aed, #f472b6);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #0f172a;
+  box-shadow: 0 14px 28px rgba(124, 58, 237, 0.35);
+}
+
+.hero__brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.hero__brand-tagline {
+  font-size: 0.75rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(203, 213, 225, 0.8);
+}
+
+.hero__brand-label {
+  font-size: 1.05rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.hero__topnav {
+  display: flex;
+  align-items: center;
+}
+
+.hero__topnav-list {
+  display: flex;
+  gap: 1.1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.hero__topnav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 1.2rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.16);
+  color: rgba(226, 232, 240, 0.88);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.hero__topnav-link:hover,
+.hero__topnav-link:focus-visible {
+  background: rgba(248, 250, 252, 0.2);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.hero__centerpiece {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: clamp(1.25rem, 2.5vw, 1.75rem);
 }
 
 .hero__tagline {
-  font-size: clamp(0.75rem, 2vw, 0.95rem);
-  letter-spacing: 0.24em;
-  text-transform: uppercase;
+  font-size: 0.75rem;
   font-weight: 600;
-  color: rgba(148, 163, 184, 0.85);
+  letter-spacing: 0.36em;
+  text-transform: uppercase;
+  color: rgba(186, 230, 253, 0.85);
 }
 
 .hero__title {
   margin: 0;
-  font-size: clamp(2.5rem, 6vw, 4.2rem);
-  line-height: 1.05;
-  letter-spacing: -0.015em;
+  font-size: clamp(2.8rem, 7vw, 4.8rem);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+  text-shadow: 0 12px 28px rgba(15, 23, 42, 0.55);
 }
 
 .hero__subtitle {
   margin: 0;
-  font-size: clamp(1rem, 2.4vw, 1.4rem);
-  color: rgba(226, 232, 240, 0.9);
+  font-size: clamp(1.05rem, 2.4vw, 1.55rem);
+  color: rgba(224, 231, 255, 0.88);
   max-width: 48ch;
 }
 
-.hero__meta {
+.hero__matchup {
+  width: min(780px, 100%);
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: stretch;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.hero__match-side {
+  position: relative;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  border-radius: 1.5rem;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  border: 1px solid rgba(248, 250, 252, 0.18);
+  backdrop-filter: blur(18px);
   display: flex;
-  flex-wrap: wrap;
-  gap: 1.25rem;
-  font-weight: 600;
+  flex-direction: column;
+  gap: 0.45rem;
+  text-align: left;
+}
+
+.hero__match-side--left {
+  box-shadow: -12px 20px 38px rgba(56, 189, 248, 0.25);
+}
+
+.hero__match-side--right {
+  box-shadow: 12px 20px 38px rgba(251, 113, 133, 0.25);
+}
+
+.hero__match-code {
+  font-size: clamp(1.8rem, 5vw, 2.6rem);
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.hero__match-name {
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
   color: rgba(226, 232, 240, 0.85);
 }
 
-.hero__meta-item {
-  position: relative;
-  padding-left: 1.5rem;
+.hero__match-note {
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.75);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-.hero__meta-item::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  width: 0.65rem;
-  height: 0.65rem;
-  border-radius: 0.35rem;
-  background: linear-gradient(135deg, #38bdf8, #a855f7);
-  transform: translateY(-50%);
+.hero__match-versus {
+  display: grid;
+  place-items: center;
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(248, 250, 252, 0.8);
+  text-shadow: 0 12px 24px rgba(15, 23, 42, 0.55);
 }
 
-.hero__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  align-items: center;
+.hero__tabs {
+  display: inline-flex;
+  gap: 0.75rem;
+  padding: 0.4rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(16px);
 }
 
-.hero__cta {
+.hero__tab {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.9rem 1.8rem;
-  background: linear-gradient(135deg, #60a5fa, #a855f7);
-  color: #0f172a;
-  border-radius: 0.9rem;
+  padding: 0.55rem 1.6rem;
+  border-radius: 999px;
   font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.88);
+  text-decoration: none;
+  transition: color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.hero__tab:hover,
+.hero__tab:focus-visible {
+  color: #0f172a;
+  background: rgba(248, 250, 252, 0.9);
+  transform: translateY(-1px);
+}
+
+.hero__qualifiers {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1rem, 2.2vw, 1.5rem);
+}
+
+.hero__qualifier {
+  position: relative;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  border-radius: 1.5rem;
+  background: linear-gradient(160deg, rgba(59, 130, 246, 0.3), rgba(76, 29, 149, 0.35));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 22px 38px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(20px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 200px;
+}
+
+.hero__qualifier:nth-child(2) {
+  background: linear-gradient(160deg, rgba(251, 113, 133, 0.3), rgba(132, 21, 141, 0.35));
+}
+
+.hero__qualifier-tag {
+  align-self: flex-start;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: rgba(15, 23, 42, 0.4);
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.hero__qualifier-title {
+  margin: 0;
+  font-size: 1.25rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero__qualifier-description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.86);
+}
+
+.hero__qualifier-cta {
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.6rem;
+  border-radius: 0.85rem;
+  background: rgba(248, 250, 252, 0.92);
+  color: #1f2937;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   text-decoration: none;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  box-shadow: 0 18px 38px rgba(96, 165, 250, 0.35);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.35);
 }
 
-.hero__cta:hover,
-.hero__cta:focus-visible {
+.hero__qualifier-cta:hover,
+.hero__qualifier-cta:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 24px 42px rgba(148, 163, 184, 0.35);
+  box-shadow: 0 22px 38px rgba(15, 23, 42, 0.45);
 }
 
-.hero__cta--secondary {
-  background: rgba(15, 23, 42, 0.55);
-  color: #e2e8f0;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  box-shadow: none;
-  backdrop-filter: blur(8px);
+.hero__footer {
+  display: grid;
+  gap: clamp(1rem, 2.5vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: stretch;
 }
 
-.hero__cta--secondary:hover,
-.hero__cta--secondary:focus-visible {
-  background: rgba(30, 41, 59, 0.75);
-  transform: translateY(-2px);
-  border-color: rgba(148, 163, 184, 0.6);
-}
-
-.hero__note {
-  color: rgba(226, 232, 240, 0.75);
-  font-size: 0.95rem;
-}
-
-.hero__aside {
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1.2rem, 2vw, 1.75rem);
-}
-
-.hero__timer {
-  padding: 1.5rem;
+.hero__stat,
+.hero__countdown,
+.hero__logos {
+  position: relative;
   border-radius: 1.25rem;
-  background: rgba(15, 23, 42, 0.7);
+  padding: clamp(1.1rem, 2vw, 1.5rem);
+  background: rgba(15, 23, 42, 0.45);
   border: 1px solid rgba(148, 163, 184, 0.25);
-  backdrop-filter: blur(14px);
-  box-shadow: 0 24px 45px rgba(8, 47, 73, 0.25);
+  backdrop-filter: blur(20px);
+  box-shadow: 0 18px 32px rgba(8, 47, 73, 0.3);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.65rem;
 }
 
-.hero__timer-label {
-  text-transform: uppercase;
+.hero__stat-label,
+.hero__countdown-label {
   font-size: 0.75rem;
-  letter-spacing: 0.28em;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
   color: rgba(148, 163, 184, 0.85);
 }
 
-.hero__timer-grid {
+.hero__stat-value {
+  font-size: clamp(1.45rem, 3vw, 2rem);
+  font-weight: 800;
+  color: #f8fafc;
+}
+
+.hero__countdown {
+  align-items: center;
+  text-align: center;
+}
+
+.hero__countdown-status {
+  font-weight: 600;
+  color: rgba(224, 231, 255, 0.88);
+}
+
+.hero__countdown-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.75rem;
 }
 
-.hero__timer-segment {
-  padding: 0.75rem 0.5rem;
+.hero__countdown-segment {
+  padding: 0.6rem 0.4rem;
   border-radius: 0.9rem;
-  background: linear-gradient(160deg, rgba(96, 165, 250, 0.2), rgba(148, 163, 184, 0.05));
-  text-align: center;
+  background: linear-gradient(160deg, rgba(148, 163, 184, 0.18), rgba(30, 64, 175, 0.35));
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.25rem;
 }
 
-.hero__timer-value {
-  font-size: 1.5rem;
+.hero__countdown-value {
+  font-size: clamp(1.4rem, 3vw, 1.85rem);
   font-weight: 700;
-  color: #f8fafc;
 }
 
-.hero__timer-unit {
-  font-size: 0.75rem;
+.hero__countdown-unit {
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: rgba(203, 213, 225, 0.8);
+  color: rgba(203, 213, 225, 0.78);
 }
 
-.hero__timer-expired {
-  font-size: 1rem;
-  color: rgba(224, 231, 255, 0.85);
-  font-weight: 600;
-}
-
-.hero__facts {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  grid-auto-rows: minmax(120px, auto);
-  gap: 1rem;
-}
-
-.hero__fact {
-  position: relative;
-  border-radius: 1.25rem;
-  padding: 1.2rem 1.25rem;
-  background: rgba(15, 23, 42, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  backdrop-filter: blur(12px);
+.hero__logos {
   display: flex;
-  gap: 0.9rem;
-  align-items: flex-start;
-  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
-  box-shadow: 0 18px 32px rgba(8, 47, 73, 0.22);
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: center;
 }
 
-.hero__fact:hover,
-.hero__fact:focus-visible {
-  transform: translateY(-4px);
-  border-color: rgba(148, 163, 184, 0.45);
-  box-shadow: 0 24px 48px rgba(8, 47, 73, 0.3);
+.hero__logo-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 72px;
+  padding: 0.55rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(248, 250, 252, 0.08);
+  color: rgba(226, 232, 240, 0.88);
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
 }
 
-.hero__fact-icon {
-  font-size: 1.65rem;
-  line-height: 1;
-}
-
-.hero__fact-title {
-  font-weight: 700;
-  font-size: 1rem;
-  color: #f8fafc;
-}
-
-.hero__fact-description {
-  margin: 0.25rem 0 0;
-  font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.85);
-}
-
-.hero--static .hero__background {
-  background: linear-gradient(135deg, #0b1120, #111827);
-}
-
-.hero--static .hero__overlay {
-  background: linear-gradient(115deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.8));
-}
-
-.hero--static .hero__poster {
-  filter: brightness(0.95) saturate(1.05);
-}
-
-@media (min-width: 1024px) {
-  .hero__inner {
-    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
-    align-items: start;
+@media (max-width: 1024px) {
+  .hero__topnav-list {
+    gap: 0.75rem;
   }
 
-  .hero__aside {
-    padding-left: clamp(1rem, 2vw, 2rem);
+  .hero__matchup {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .hero__timer-grid {
-    gap: 1rem;
+  .hero__match-versus {
+    grid-column: span 2;
+    order: -1;
   }
 
-  .hero__timer-value {
-    font-size: 1.85rem;
+  .hero__countdown-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -483,32 +630,58 @@ main.app {
     min-height: auto;
   }
 
-  .hero__inner {
-    padding: clamp(2rem, 8vw, 3rem) clamp(1.25rem, 6vw, 2.25rem);
+  .hero__topbar {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
-  .hero__timer-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .hero__centerpiece {
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .hero__matchup {
+    width: 100%;
+  }
+
+  .hero__tabs {
+    align-self: flex-start;
+  }
+
+  .hero__footer {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   }
 }
 
-@media (max-width: 540px) {
-  .hero__facts {
-    grid-template-columns: repeat(1, minmax(0, 1fr));
+@media (max-width: 560px) {
+  .hero__topnav {
+    width: 100%;
   }
 
-  .hero__note {
-    font-size: 0.9rem;
+  .hero__topnav-list {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .hero__tabs {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .hero__tab {
+    flex: 1;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hero__video {
-    display: none;
+  .hero__overlay {
+    background: linear-gradient(120deg, rgba(8, 4, 34, 0.92), rgba(17, 22, 57, 0.92));
   }
 
-  .hero__overlay {
-    background: linear-gradient(115deg, rgba(15, 23, 42, 0.92), rgba(30, 41, 59, 0.82));
+  .hero__topnav-link,
+  .hero__tab,
+  .hero__qualifier-cta {
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- redesign the hero feature around a versus style esports matchup experience
- refresh the hero styling with neon gradients, matchup cards, qualifier call-to-actions, and scoreboard footer
- update the hero configuration to provide branding links, qualifier metadata, and countdown assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f7647c2db483238f993ae64f08670f