### PR TITLE
feat: add animated accessible schedule timeline

### DIFF
--- a/src/features/Schedule/Schedule.jsx
+++ b/src/features/Schedule/Schedule.jsx
@@ -1,34 +1,146 @@
+import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
-const Schedule = ({ data }) => (
-  <div className="schedule">
-    <p className="schedule__description">{data.description}</p>
-    <ul className="schedule__list">
-      {data.items.map((item) => (
-        <li key={item.id} className="schedule__item">
-          <time className="schedule__time" dateTime={item.isoDate}>
-            {item.date}
-          </time>
-          <div className="schedule__details">
-            <h4 className="schedule__title">{item.title}</h4>
-            <p className="schedule__location">{item.location}</p>
-          </div>
-        </li>
-      ))}
-    </ul>
-  </div>
-);
+const Schedule = ({ data }) => {
+  const itemRefs = useRef([]);
+
+  useEffect(() => {
+    const nodes = itemRefs.current.filter(Boolean);
+
+    if (nodes.length === 0) {
+      return undefined;
+    }
+
+    const reveal = (element) => {
+      element.classList.add('schedule__item--visible');
+    };
+
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) {
+      nodes.forEach(reveal);
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            reveal(entry.target);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      {
+        threshold: 0.35,
+        rootMargin: '0px 0px -10% 0px',
+      },
+    );
+
+    nodes.forEach((node) => observer.observe(node));
+
+    return () => observer.disconnect();
+  }, [data.items]);
+
+  const setItemRef = (index) => (node) => {
+    itemRefs.current[index] = node;
+  };
+
+  return (
+    <section
+      className="schedule"
+      aria-labelledby="schedule-title"
+      aria-describedby="schedule-description schedule-a11y"
+    >
+      <header className="schedule__header">
+        <h3 id="schedule-title" className="schedule__heading">
+          {data.title}
+        </h3>
+        <p id="schedule-description" className="schedule__description">
+          {data.description}
+        </p>
+        <p id="schedule-a11y" className="schedule__sr">
+          {data.screenReaderDescription}
+        </p>
+      </header>
+      <ol className="schedule__timeline">
+        {data.items.map((item, index) => {
+          const baseId = `schedule-${item.id}`;
+          const descriptionId = `${baseId}-description`;
+          const dateId = `${baseId}-date`;
+          const srId = `${baseId}-sr`;
+
+          return (
+            <li
+              key={item.id}
+              className="schedule__item"
+              ref={setItemRef(index)}
+              aria-labelledby={`${baseId}-title`}
+              aria-describedby={`${dateId} ${descriptionId} ${srId}`}
+            >
+              <div className="schedule__rail" aria-hidden="true" />
+              <div className="schedule__marker" aria-hidden="true">
+                <span className="schedule__icon" aria-hidden="true">
+                  {item.icon}
+                </span>
+              </div>
+              <div className="schedule__content">
+                <time id={dateId} className="schedule__date" dateTime={item.dateRange.start}>
+                  {item.dateRange.label}
+                </time>
+                <h4 id={`${baseId}-title`} className="schedule__title">
+                  {item.title}
+                </h4>
+                <p id={descriptionId} className="schedule__text">
+                  {item.description}
+                </p>
+                <div className="schedule__actions">
+                  <a className="schedule__link" href={item.rulesLink.href}>
+                    {item.rulesLink.label}
+                  </a>
+                </div>
+                <details className="schedule__accordion">
+                  <summary className="schedule__accordion-summary">Preparation tips</summary>
+                  <ul className="schedule__tips">
+                    {item.tips.map((tip, tipIndex) => (
+                      <li key={`${item.id}-tip-${tipIndex}`} className="schedule__tip">
+                        {tip}
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+                <span id={srId} className="schedule__sr">
+                  {item.a11yDescription}
+                </span>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+};
 
 Schedule.propTypes = {
   data: PropTypes.shape({
+    title: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
+    screenReaderDescription: PropTypes.string.isRequired,
     items: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-        isoDate: PropTypes.string.isRequired,
-        date: PropTypes.string.isRequired,
         title: PropTypes.string.isRequired,
-        location: PropTypes.string.isRequired,
+        icon: PropTypes.string.isRequired,
+        dateRange: PropTypes.shape({
+          label: PropTypes.string.isRequired,
+          start: PropTypes.string.isRequired,
+          end: PropTypes.string.isRequired,
+        }).isRequired,
+        description: PropTypes.string.isRequired,
+        rulesLink: PropTypes.shape({
+          href: PropTypes.string.isRequired,
+          label: PropTypes.string.isRequired,
+        }).isRequired,
+        tips: PropTypes.arrayOf(PropTypes.string).isRequired,
+        a11yDescription: PropTypes.string.isRequired,
       }),
     ).isRequired,
   }).isRequired,

--- a/src/features/Schedule/config.json
+++ b/src/features/Schedule/config.json
@@ -1,26 +1,87 @@
 {
-  "description": "Key milestones planned for the next sprint.",
+  "title": "Competition Roadmap",
+  "description": "Track each milestone to keep your team ready for the next challenge.",
+  "screenReaderDescription": "Timeline covers registration and roster checks, the first scrimmage, qualifying matches, and the championship finals. Each stop includes preparation tips and a link to the relevant rulebook section.",
   "items": [
     {
-      "id": "kickoff",
-      "date": "Jan 8",
-      "isoDate": "2025-01-08",
-      "title": "Sprint Kick-off",
-      "location": "Remote stand-up"
+      "id": "registration",
+      "title": "Registration & Rosters",
+      "icon": "📝",
+      "dateRange": {
+        "label": "Jan 8 – Jan 12",
+        "start": "2025-01-08",
+        "end": "2025-01-12"
+      },
+      "description": "Lock in your team roster, confirm eligibility, and submit entrance fees.",
+      "rulesLink": {
+        "href": "https://rules.example.com/registration",
+        "label": "Registration rules"
+      },
+      "tips": [
+        "Double-check age and eligibility certificates before submission.",
+        "Coordinate with finance to confirm the payment receipt."
+      ],
+      "a11yDescription": "Registration and roster submission runs from January 8 through January 12. Prepare eligibility proofs and confirm payment receipts."
     },
     {
-      "id": "design-review",
-      "date": "Jan 12",
-      "isoDate": "2025-01-12",
-      "title": "Design Review",
-      "location": "Product room"
+      "id": "scrimmage",
+      "title": "Early Scrimmage",
+      "icon": "🤝",
+      "dateRange": {
+        "label": "Jan 15",
+        "start": "2025-01-15",
+        "end": "2025-01-15"
+      },
+      "description": "Shake out strategies with a collaborative scrimmage to gather feedback from mentors.",
+      "rulesLink": {
+        "href": "https://rules.example.com/scrimmage",
+        "label": "Scrimmage guidelines"
+      },
+      "tips": [
+        "Bring prototype builds for live testing.",
+        "Capture mentor feedback and log it for the next sprint."
+      ],
+      "a11yDescription": "Scrimmage day is January 15. Teams test strategies with mentors and capture improvement notes."
     },
     {
-      "id": "demo",
-      "date": "Jan 19",
-      "isoDate": "2025-01-19",
-      "title": "Sprint Demo",
-      "location": "Town hall"
+      "id": "qualifiers",
+      "title": "Regional Qualifiers",
+      "icon": "🏆",
+      "dateRange": {
+        "label": "Jan 22 – Jan 24",
+        "start": "2025-01-22",
+        "end": "2025-01-24"
+      },
+      "description": "Compete in ranked matches to secure a berth for the finals.",
+      "rulesLink": {
+        "href": "https://rules.example.com/qualifiers",
+        "label": "Qualifier regulations"
+      },
+      "tips": [
+        "Study the tie-break criteria and prepare backup line-ups.",
+        "Assign a scout to track opponent strategies in real time."
+      ],
+      "a11yDescription": "Regional qualifiers run from January 22 through January 24 with ranked matches determining finals placement."
+    },
+    {
+      "id": "championship",
+      "title": "Championship Finals",
+      "icon": "🎉",
+      "dateRange": {
+        "label": "Jan 31",
+        "start": "2025-01-31",
+        "end": "2025-01-31"
+      },
+      "description": "Showcase your best performance and celebrate the season with the community.",
+      "rulesLink": {
+        "href": "https://rules.example.com/championship",
+        "label": "Finals handbook"
+      },
+      "tips": [
+        "Rehearse the presentation deck and highlight reels.",
+        "Plan travel logistics early for the closing ceremony."
+      ],
+      "a11yDescription": "Championship finals take place on January 31 with presentations and closing ceremonies."
     }
   ]
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1664,3 +1664,263 @@ main.app {
     width: 100%;
   }
 }
+
+/* Schedule timeline */
+.schedule {
+  display: grid;
+  gap: clamp(1.75rem, 2.5vw, 2.5rem);
+  background: radial-gradient(circle at top left, rgba(96, 165, 250, 0.1), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(129, 140, 248, 0.1), transparent 50%),
+    #ffffff;
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  border-radius: 1.5rem;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.08);
+  position: relative;
+  overflow: hidden;
+}
+
+.schedule::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), transparent 60%);
+  pointer-events: none;
+}
+
+.schedule__header {
+  display: grid;
+  gap: 1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.schedule__heading {
+  margin: 0;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  letter-spacing: -0.01em;
+}
+
+.schedule__description {
+  margin: 0;
+  font-size: clamp(1rem, 1.8vw, 1.1rem);
+  color: #475569;
+  line-height: 1.7;
+}
+
+.schedule__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.schedule__timeline {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+  position: relative;
+  z-index: 1;
+}
+
+.schedule__item {
+  display: grid;
+  grid-template-columns: clamp(48px, 6vw, 64px) 1fr;
+  gap: clamp(1.25rem, 2vw, 1.75rem);
+  align-items: start;
+  position: relative;
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.schedule__item--visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.schedule__rail {
+  position: absolute;
+  left: clamp(22px, 3vw, 32px);
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(96, 165, 250, 0.2), rgba(37, 99, 235, 0.1));
+  transform: translateX(-50%);
+}
+
+.schedule__marker {
+  position: relative;
+  width: clamp(48px, 6vw, 64px);
+  height: clamp(48px, 6vw, 64px);
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.35), rgba(129, 140, 248, 0.5));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.2);
+  animation: schedulePulse 6s ease-in-out infinite;
+}
+
+.schedule__icon {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+
+.schedule__content {
+  background: rgba(248, 250, 252, 0.95);
+  border-radius: 1.2rem;
+  padding: clamp(1.25rem, 2.4vw, 1.75rem);
+  box-shadow: 0 20px 45px rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: grid;
+  gap: 0.9rem;
+}
+
+.schedule__date {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #1d4ed8;
+}
+
+.schedule__title {
+  margin: 0;
+  font-size: clamp(1.2rem, 2vw, 1.45rem);
+  letter-spacing: -0.01em;
+  color: #0f172a;
+}
+
+.schedule__text {
+  margin: 0;
+  color: #475569;
+  line-height: 1.7;
+  font-size: 1rem;
+}
+
+.schedule__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.schedule__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #1d4ed8;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  position: relative;
+}
+
+.schedule__link::after {
+  content: '↗';
+  font-size: 0.85rem;
+  transition: transform 0.2s ease;
+}
+
+.schedule__link:hover::after,
+.schedule__link:focus-visible::after {
+  transform: translate(4px, -4px);
+}
+
+.schedule__link:focus-visible {
+  outline: 3px solid rgba(96, 165, 250, 0.5);
+  outline-offset: 4px;
+  border-radius: 0.5rem;
+}
+
+.schedule__accordion {
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  overflow: hidden;
+}
+
+.schedule__accordion-summary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.9rem 1.2rem;
+  font-weight: 600;
+  color: #0f172a;
+  position: relative;
+}
+
+.schedule__accordion-summary::marker {
+  display: none;
+}
+
+.schedule__accordion-summary::-webkit-details-marker {
+  display: none;
+}
+
+.schedule__accordion[open] .schedule__accordion-summary {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.schedule__tips {
+  margin: 0;
+  padding: 1rem 1.4rem 1.2rem;
+  display: grid;
+  gap: 0.75rem;
+  color: #475569;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.schedule__tip {
+  position: relative;
+  padding-left: 1.1rem;
+}
+
+.schedule__tip::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.55rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #60a5fa, #38bdf8);
+}
+
+@keyframes schedulePulse {
+  0%,
+  100% {
+    transform: scale(1);
+    box-shadow: 0 16px 30px rgba(15, 23, 42, 0.18);
+  }
+  50% {
+    transform: scale(1.05);
+    box-shadow: 0 24px 40px rgba(15, 23, 42, 0.24);
+  }
+}
+
+@media (max-width: 768px) {
+  .schedule {
+    padding: clamp(1.5rem, 6vw, 2rem);
+  }
+
+  .schedule__item {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .schedule__rail {
+    display: none;
+  }
+
+  .schedule__marker {
+    justify-self: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the schedule feature with an animated, accessible timeline that reveals stages on scroll and provides accordion guidance
- expand the schedule configuration with date ranges, descriptions, icons, preparation tips, and rule references
- style the timeline, accordions, and screen-reader helpers for the new experience

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f76f971ccc832381391b93d1d7edb9