### PR TITLE
feat: add spectators broadcast section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Schedule from './features/Schedule/Schedule.jsx';
 import News from './features/News/News.jsx';
 import Divisions from './features/Divisions/Divisions.jsx';
 import RegistrationCta from './features/RegistrationCta/RegistrationCta.jsx';
+import Spectators from './features/Spectators/Spectators.jsx';
 import heroConfig from './features/Hero/config.json';
 import overviewConfig from './features/Overview/config.json';
 import benefitsConfig from './features/Benefits/config.json';
@@ -19,6 +20,7 @@ import scheduleConfig from './features/Schedule/config.json';
 import newsConfig from './features/News/config.json';
 import divisionsConfig from './features/Divisions/config.json';
 import registrationCtaConfig from './features/RegistrationCta/config.json';
+import spectatorsConfig from './features/Spectators/config.json';
 
 const App = () => {
   const sections = [
@@ -87,6 +89,18 @@ const App = () => {
       title: 'Новости экосистемы',
       component: <News data={newsConfig} />,
       navLabel: 'Новости',
+    },
+    {
+      id: 'spectators',
+      title: 'Для зрителей',
+      component: (
+        <Spectators
+          streams={spectatorsConfig.streams}
+          lanFinal={spectatorsConfig.lanFinal}
+        />
+      ),
+      navLabel: 'Зрителям',
+      variant: 'spectators',
     },
     {
       id: 'bracket',

--- a/src/features/Spectators/Spectators.jsx
+++ b/src/features/Spectators/Spectators.jsx
@@ -1,0 +1,150 @@
+import PropTypes from 'prop-types';
+
+const renderPreview = (preview, title, watchUrl) => {
+  if (!preview) {
+    return null;
+  }
+
+  if (preview.type === 'gallery' && Array.isArray(preview.images)) {
+    return (
+      <div className="spectators__gallery" role="group" aria-label={`Фотографии трансляции «${title}»`}>
+        {preview.images.map((image) => (
+          <figure key={image.src} className="spectators__gallery-item">
+            <img src={image.src} alt={image.alt} loading="lazy" />
+          </figure>
+        ))}
+      </div>
+    );
+  }
+
+  if (preview.type === 'video') {
+    return (
+      <a
+        className="spectators__video"
+        href={watchUrl}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={`Посмотреть видеопревью «${title}»`}
+      >
+        <img src={preview.thumbnail} alt={preview.label || `Превью трансляции ${title}`} loading="lazy" />
+        <div className="spectators__video-meta" aria-hidden="true">
+          <span className="spectators__video-icon">▶</span>
+          <span className="spectators__video-label">{preview.label}</span>
+          {preview.duration ? (
+            <span className="spectators__video-duration">{preview.duration}</span>
+          ) : null}
+        </div>
+      </a>
+    );
+  }
+
+  return null;
+};
+
+const Spectators = ({ streams, lanFinal }) => (
+  <div className="spectators">
+    <section className="spectators__streams" aria-label="Онлайн-трансляции YarCyberSeason">
+      {streams.map(({ id, title, description, platform, schedule, watchUrl, calendarUrl, tags, preview }) => (
+        <article key={id} className="spectators__card">
+          <header className="spectators__card-header">
+            <span className="spectators__badge" aria-label={`Платформа: ${platform}`}>
+              {platform}
+            </span>
+            <span className="spectators__schedule">{schedule}</span>
+          </header>
+          <h3 className="spectators__card-title">{title}</h3>
+          <p className="spectators__card-description">{description}</p>
+          {tags?.length ? (
+            <ul className="spectators__tags" aria-label="Особенности трансляции">
+              {tags.map((tag) => (
+                <li key={tag} className="spectators__tag">
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {renderPreview(preview, title, watchUrl)}
+          <div className="spectators__actions" role="group" aria-label={`Действия для трансляции «${title}»`}>
+            <a className="spectators__button spectators__button--primary" href={watchUrl} target="_blank" rel="noreferrer">
+              Смотреть стрим
+            </a>
+            <a className="spectators__button spectators__button--secondary" href={calendarUrl} target="_blank" rel="noreferrer">
+              Добавить в календарь
+            </a>
+          </div>
+        </article>
+      ))}
+    </section>
+    <section className="spectators__lan" aria-labelledby="spectators-lan-title">
+      <div className="spectators__lan-info">
+        <h3 id="spectators-lan-title" className="spectators__lan-title">
+          {lanFinal.title}
+        </h3>
+        <div className="spectators__lan-meta">
+          <span className="spectators__lan-date" aria-label="Дата и время офлайн-финала">
+            🗓️ {lanFinal.date}
+          </span>
+          <span className="spectators__lan-location" aria-label="Место проведения офлайн-финала">
+            📍 {lanFinal.location}
+          </span>
+        </div>
+        <p className="spectators__lan-description">{lanFinal.description}</p>
+        {lanFinal.highlights?.length ? (
+          <ul className="spectators__lan-list">
+            {lanFinal.highlights.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      {lanFinal.media?.type === 'gallery' && Array.isArray(lanFinal.media.images) ? (
+        <div className="spectators__lan-media" role="group" aria-label="Кадры офлайн-финала">
+          {lanFinal.media.images.map((image) => (
+            <figure key={image.src} className="spectators__lan-media-item">
+              <img src={image.src} alt={image.alt} loading="lazy" />
+            </figure>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  </div>
+);
+
+const mediaShape = PropTypes.shape({
+  type: PropTypes.string.isRequired,
+  images: PropTypes.arrayOf(
+    PropTypes.shape({
+      src: PropTypes.string.isRequired,
+      alt: PropTypes.string.isRequired,
+    }),
+  ),
+  thumbnail: PropTypes.string,
+  label: PropTypes.string,
+  duration: PropTypes.string,
+});
+
+Spectators.propTypes = {
+  streams: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired,
+      platform: PropTypes.string.isRequired,
+      schedule: PropTypes.string.isRequired,
+      watchUrl: PropTypes.string.isRequired,
+      calendarUrl: PropTypes.string.isRequired,
+      tags: PropTypes.arrayOf(PropTypes.string),
+      preview: mediaShape,
+    }),
+  ).isRequired,
+  lanFinal: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    date: PropTypes.string.isRequired,
+    location: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    highlights: PropTypes.arrayOf(PropTypes.string),
+    media: mediaShape,
+  }).isRequired,
+};
+
+export default Spectators;

--- a/src/features/Spectators/config.json
+++ b/src/features/Spectators/config.json
@@ -1,0 +1,92 @@
+{
+  "streams": [
+    {
+      "id": "qualifiers-final",
+      "title": "Финал онлайн-отборов",
+      "description": "Разогрев с аналитиками, прямая трансляция решающих матчей и студийные комментарии от приглашённых экспертов.",
+      "platform": "YouTube",
+      "schedule": "14 ноября · 19:00 (МСК)",
+      "watchUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "calendarUrl": "https://calendar.google.com/calendar/render?action=TEMPLATE&text=%D0%A4%D0%B8%D0%BD%D0%B0%D0%BB+%D0%BE%D1%82%D0%B1%D0%BE%D1%80%D0%BE%D0%B2+YarCyberSeason&details=%D0%A1%D0%BC%D0%BE%D1%82%D1%80%D0%B8+%D1%84%D0%B8%D0%BD%D0%B0%D0%BB+%D0%BE%D0%BD%D0%BB%D0%B0%D0%B9%D0%BD-%D0%BE%D1%82%D0%B1%D0%BE%D1%80%D0%BE%D0%B2+YarCyberSeason&dates=20241114T160000Z/20241114T183000Z",
+      "tags": ["Best-of-5", "Экспертный разбор"],
+      "preview": {
+        "type": "video",
+        "thumbnail": "https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=800&q=80",
+        "label": "Трейлер трансляции",
+        "duration": "2:35"
+      }
+    },
+    {
+      "id": "community-show",
+      "title": "Community Show с капитанами",
+      "description": "Панель с капитанами дивизионов, интервью о стратегии и интерактив с зрителями в прямом эфире.",
+      "platform": "VK Play",
+      "schedule": "21 ноября · 18:30 (МСК)",
+      "watchUrl": "https://vkplay.live/",
+      "calendarUrl": "https://calendar.google.com/calendar/render?action=TEMPLATE&text=Community+Show+YarCyberSeason&details=%D0%A3%D1%87%D0%B0%D1%81%D1%82%D0%B2%D1%83%D0%B9+%D0%B2+Community+Show+YarCyberSeason&dates=20241121T153000Z/20241121T170000Z",
+      "tags": ["Live QA", "Интерактив"],
+      "preview": {
+        "type": "gallery",
+        "images": [
+          {
+            "src": "https://images.unsplash.com/photo-1517677129300-07b130802f46?auto=format&fit=crop&w=600&q=80",
+            "alt": "Киберспортсмен делится стратегией"
+          },
+          {
+            "src": "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=600&q=80",
+            "alt": "Обсуждение команды в студии"
+          },
+          {
+            "src": "https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=600&q=80",
+            "alt": "Интерактив с аудиторией"
+          }
+        ]
+      }
+    },
+    {
+      "id": "final-draft",
+      "title": "Жеребьёвка LAN-финала",
+      "description": "Торжественная жеребьёвка, выбор карт и анализ шансов команд перед очными играми.",
+      "platform": "Twitch",
+      "schedule": "30 ноября · 17:00 (МСК)",
+      "watchUrl": "https://www.twitch.tv/",
+      "calendarUrl": "https://calendar.google.com/calendar/render?action=TEMPLATE&text=%D0%96%D0%B5%D1%80%D0%B5%D0%B1%D1%8C%D1%91%D0%B2%D0%BA%D0%B0+LAN-%D1%84%D0%B8%D0%BD%D0%B0%D0%BB%D0%B0+YarCyberSeason&details=%D0%A3%D0%B7%D0%BD%D0%B0%D0%B9+%D0%BF%D0%B0%D1%80%D1%8B+LAN-%D1%84%D0%B8%D0%BD%D0%B0%D0%BB%D0%B0+YarCyberSeason&dates=20241130T140000Z/20241130T153000Z",
+      "tags": ["Live Draft", "Статистика"],
+      "preview": {
+        "type": "video",
+        "thumbnail": "https://images.unsplash.com/photo-1511379938547-c1f69419868d?auto=format&fit=crop&w=800&q=80",
+        "label": "Анонс LAN-финала",
+        "duration": "1:48"
+      }
+    }
+  ],
+  "lanFinal": {
+    "title": "Офлайн-финал в Ярославле",
+    "date": "7 декабря · 12:00 (МСК)",
+    "location": "Конгресс-центр, Ярославль",
+    "description": "Лучшие команды встретятся на сцене, чтобы сразиться за чемпионский титул YarCyberSeason. Зрителей ждут активности от партнёров, фан-зона и зона автографов.",
+    "highlights": [
+      "Главная сцена с круговым экраном 360°",
+      "Павильон технологических демо и VR-зона",
+      "Конкурсы с призами от спонсоров и команды продакшена",
+      "Лаундж для зрителей с настольными играми и мерч-зоной"
+    ],
+    "media": {
+      "type": "gallery",
+      "images": [
+        {
+          "src": "https://images.unsplash.com/photo-1516245834210-c4c142787335?auto=format&fit=crop&w=800&q=80",
+          "alt": "Сцена киберспортивного турнира"
+        },
+        {
+          "src": "https://images.unsplash.com/photo-1515162305285-0293e47ef015?auto=format&fit=crop&w=800&q=80",
+          "alt": "Зрители на трибунах арены"
+        },
+        {
+          "src": "https://images.unsplash.com/photo-1459749411175-04bf5292ceea?auto=format&fit=crop&w=800&q=80",
+          "alt": "Киберспортивный игрок на сцене"
+        }
+      ]
+    }
+  }
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2234,3 +2234,321 @@ main.app {
     gap: 0.5rem;
   }
 }
+
+.section--spectators {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(76, 29, 149, 0.08)), #ffffff;
+}
+
+.spectators {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2.5rem, 6vw, 3.5rem);
+}
+
+.spectators__streams {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.spectators__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.4rem;
+  border-radius: 1.25rem;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.82), rgba(37, 99, 235, 0.45));
+  color: #f8fafc;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.32);
+  overflow: hidden;
+}
+
+.spectators__card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(148, 163, 184, 0.2), transparent 55%),
+    radial-gradient(circle at 80% 10%, rgba(96, 165, 250, 0.25), transparent 60%);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.spectators__card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.spectators__card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.spectators__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(226, 232, 240, 0.18);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(248, 250, 252, 0.8);
+}
+
+.spectators__schedule {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.75);
+}
+
+.spectators__card-title {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.spectators__card-description {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.spectators__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.spectators__tag {
+  padding: 0.35rem 0.65rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.spectators__gallery {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  border-radius: 1rem;
+  overflow: hidden;
+}
+
+.spectators__gallery-item {
+  margin: 0;
+}
+
+.spectators__gallery-item img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.spectators__video {
+  position: relative;
+  display: block;
+  border-radius: 1rem;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.9);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.spectators__video:hover,
+.spectators__video:focus-visible {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 32px rgba(59, 130, 246, 0.35);
+}
+
+.spectators__video img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  object-fit: cover;
+}
+
+.spectators__video-meta {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.88) 100%);
+  color: #f8fafc;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.spectators__video-icon {
+  font-size: 1.1rem;
+}
+
+.spectators__video-duration {
+  margin-left: auto;
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.65);
+  font-size: 0.75rem;
+}
+
+.spectators__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: auto;
+}
+
+.spectators__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.2rem;
+  border-radius: 0.85rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.spectators__button--primary {
+  background: linear-gradient(135deg, #60a5fa, #a855f7);
+  color: #0f172a;
+  box-shadow: 0 12px 24px rgba(96, 165, 250, 0.35);
+}
+
+.spectators__button--primary:hover,
+.spectators__button--primary:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 32px rgba(96, 165, 250, 0.45);
+}
+
+.spectators__button--secondary {
+  background: rgba(15, 23, 42, 0.65);
+  color: rgba(248, 250, 252, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.spectators__button--secondary:hover,
+.spectators__button--secondary:focus-visible {
+  transform: translateY(-3px);
+  background: rgba(15, 23, 42, 0.8);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.38);
+}
+
+.spectators__lan {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  padding: clamp(1.75rem, 5vw, 2.5rem);
+  border-radius: 1.5rem;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.95), rgba(76, 29, 149, 0.85));
+  color: #f8fafc;
+  box-shadow: 0 26px 48px rgba(15, 23, 42, 0.38);
+}
+
+.spectators__lan-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.spectators__lan-title {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.spectators__lan-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1.25rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.spectators__lan-description {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.spectators__lan-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.55rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.spectators__lan-media {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.spectators__lan-media-item {
+  margin: 0;
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.35);
+}
+
+.spectators__lan-media-item img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+@media (max-width: 1024px) {
+  .spectators__lan {
+    grid-template-columns: 1fr;
+  }
+
+  .spectators__lan-media {
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .spectators__streams {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .spectators__actions {
+    flex-direction: column;
+  }
+
+  .spectators__button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .spectators__gallery {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .spectators__lan-media {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}


### PR DESCRIPTION
## Summary
- add a spectators section with streaming cards and calls to action
- configure broadcast data via streams array and LAN final block
- style multimedia previews and responsive layout for the new section

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7741960488323ab31666a68c1d3f3