### PR TITLE
Add sponsors section with grouped logos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import RegistrationCta from './features/RegistrationCta/RegistrationCta.jsx';
 import Spectators from './features/Spectators/Spectators.jsx';
 import Community from './features/Community/Community.jsx';
 import Stats from './features/Stats/Stats.jsx';
+import Sponsors from './features/Sponsors/Sponsors.jsx';
 import heroConfig from './features/Hero/config.json';
 import overviewConfig from './features/Overview/config.json';
 import benefitsConfig from './features/Benefits/config.json';
@@ -25,6 +26,7 @@ import registrationCtaConfig from './features/RegistrationCta/config.json';
 import spectatorsConfig from './features/Spectators/config.json';
 import communityConfig from './features/Community/config.json';
 import statsConfig from './features/Stats/config.json';
+import sponsorsConfig from './features/Sponsors/config.json';
 
 const App = () => {
   const sections = [
@@ -106,6 +108,13 @@ const App = () => {
       component: <Community data={communityConfig} />,
       navLabel: 'Комьюнити',
       variant: 'community',
+    },
+    {
+      id: 'sponsors',
+      title: 'Партнёры и спонсоры',
+      component: <Sponsors data={sponsorsConfig} />,
+      navLabel: 'Партнёры',
+      variant: 'sponsors',
     },
     {
       id: 'spectators',

--- a/src/features/Sponsors/Sponsors.jsx
+++ b/src/features/Sponsors/Sponsors.jsx
@@ -1,0 +1,86 @@
+import PropTypes from 'prop-types';
+
+const Sponsors = ({ data }) => {
+  const { intro, tiers } = data;
+
+  return (
+    <div className="sponsors">
+      <div className="sponsors__intro">
+        {intro?.eyebrow ? (
+          <span className="sponsors__eyebrow">{intro.eyebrow}</span>
+        ) : null}
+        {intro?.description ? (
+          <p className="sponsors__description">{intro.description}</p>
+        ) : null}
+        {intro?.download ? (
+          <a
+            className="sponsors__cta"
+            href={intro.download.href}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {intro.download.label}
+          </a>
+        ) : null}
+      </div>
+      <div className="sponsors__tiers">
+        {tiers.map((tier) => (
+          <section key={tier.id} className="sponsors__tier" aria-labelledby={`${tier.id}-heading`}>
+            <h3 id={`${tier.id}-heading`} className="sponsors__tier-title">
+              {tier.label}
+            </h3>
+            <ul className="sponsors__logos">
+              {tier.sponsors.map((sponsor) => (
+                <li key={sponsor.name} className="sponsors__logo-item">
+                  <a
+                    className="sponsors__logo-link"
+                    href={sponsor.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    aria-label={`Перейти на сайт ${sponsor.name}`}
+                  >
+                    <img
+                      className="sponsors__logo"
+                      src={sponsor.logo}
+                      alt={sponsor.alt || sponsor.name}
+                      loading="lazy"
+                    />
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+Sponsors.propTypes = {
+  data: PropTypes.shape({
+    intro: PropTypes.shape({
+      eyebrow: PropTypes.string,
+      description: PropTypes.string,
+      download: PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        href: PropTypes.string.isRequired,
+      }),
+    }).isRequired,
+    tiers: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        sponsors: PropTypes.arrayOf(
+          PropTypes.shape({
+            name: PropTypes.string.isRequired,
+            logo: PropTypes.string.isRequired,
+            url: PropTypes.string.isRequired,
+            alt: PropTypes.string,
+          }),
+        ).isRequired,
+      }),
+    ).isRequired,
+  }).isRequired,
+};
+
+export default Sponsors;

--- a/src/features/Sponsors/config.json
+++ b/src/features/Sponsors/config.json
@@ -1,0 +1,84 @@
+{
+  "intro": {
+    "eyebrow": "Партнёрская экосистема",
+    "description": "Крупные технологические бренды, образовательные площадки и локальные бизнесы поддерживают YarCyberSeason, помогая развивать таланты и инфраструктуру региона.",
+    "download": {
+      "label": "Скачать спонсорский пакет",
+      "href": "https://yarcyberseason.ru/files/yarcyberseason-sponsor-pack.pdf"
+    }
+  },
+  "tiers": [
+    {
+      "id": "general",
+      "label": "Генеральные партнёры",
+      "sponsors": [
+        {
+          "name": "Microsoft",
+          "logo": "https://upload.wikimedia.org/wikipedia/commons/4/44/Microsoft_logo.svg",
+          "url": "https://www.microsoft.com/",
+          "alt": "Логотип Microsoft"
+        },
+        {
+          "name": "Amazon Web Services",
+          "logo": "https://upload.wikimedia.org/wikipedia/commons/9/93/Amazon_Web_Services_Logo.svg",
+          "url": "https://aws.amazon.com/",
+          "alt": "Логотип Amazon Web Services"
+        }
+      ]
+    },
+    {
+      "id": "official",
+      "label": "Официальные партнёры",
+      "sponsors": [
+        {
+          "name": "Google Cloud",
+          "logo": "https://upload.wikimedia.org/wikipedia/commons/0/08/Google_Logo.svg",
+          "url": "https://cloud.google.com/",
+          "alt": "Логотип Google"
+        },
+        {
+          "name": "Intel",
+          "logo": "https://upload.wikimedia.org/wikipedia/commons/2/2f/Intel_logo_%282020%2C_dark_blue%29.svg",
+          "url": "https://www.intel.ru/",
+          "alt": "Логотип Intel"
+        },
+        {
+          "name": "Red Bull",
+          "logo": "https://upload.wikimedia.org/wikipedia/fr/3/3a/Red_Bull.svg",
+          "url": "https://www.redbull.com/",
+          "alt": "Логотип Red Bull"
+        }
+      ]
+    },
+    {
+      "id": "community",
+      "label": "Сообщество и образовательные партнёры",
+      "sponsors": [
+        {
+          "name": "Logitech G",
+          "logo": "https://upload.wikimedia.org/wikipedia/commons/2/2d/Logitech_logo.svg",
+          "url": "https://www.logitechg.com/",
+          "alt": "Логотип Logitech"
+        },
+        {
+          "name": "Skillbox",
+          "logo": "https://upload.wikimedia.org/wikipedia/commons/d/d3/Skillbox_logo.svg",
+          "url": "https://skillbox.ru/",
+          "alt": "Логотип Skillbox"
+        },
+        {
+          "name": "GeekBrains",
+          "logo": "https://upload.wikimedia.org/wikipedia/commons/3/3a/GeekBrains_logo.svg",
+          "url": "https://gb.ru/",
+          "alt": "Логотип GeekBrains"
+        },
+        {
+          "name": "VK Play",
+          "logo": "https://upload.wikimedia.org/wikipedia/commons/d/de/VK_Logo.svg",
+          "url": "https://vkplay.ru/",
+          "alt": "Логотип VK Play"
+        }
+      ]
+    }
+  ]
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -2940,3 +2940,163 @@ main.app {
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+.sponsors {
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+.sponsors__intro {
+  display: grid;
+  gap: 0.75rem;
+  padding: clamp(1.5rem, 4vw, 2rem);
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.16), rgba(168, 85, 247, 0.14));
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+}
+
+.sponsors__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: fit-content;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: rgba(37, 99, 235, 0.95);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.sponsors__description {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.65;
+  color: rgba(15, 23, 42, 0.78);
+}
+
+.sponsors__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: fit-content;
+  padding: 0.65rem 1.3rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(135deg, #60a5fa, #a855f7);
+  color: #0f172a;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 16px 32px rgba(96, 165, 250, 0.32);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sponsors__cta:hover,
+.sponsors__cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(96, 165, 250, 0.4);
+}
+
+.sponsors__tiers {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+}
+
+.sponsors__tier {
+  display: grid;
+  gap: 1rem;
+  padding: clamp(1.4rem, 3.5vw, 1.75rem);
+  border-radius: 1.2rem;
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.sponsors__tier-title {
+  margin: 0;
+  font-size: clamp(1.1rem, 2.6vw, 1.35rem);
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.sponsors__logos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: clamp(1rem, 2.5vw, 1.5rem);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sponsors__logo-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(0.85rem, 2.5vw, 1.2rem);
+  border-radius: 1rem;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 10px 18px rgba(148, 163, 184, 0.18);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.sponsors__logo {
+  display: block;
+  max-width: min(160px, 100%);
+  max-height: 60px;
+  filter: grayscale(100%) saturate(0) brightness(0.85);
+  transition: filter 0.4s ease, transform 0.4s ease;
+}
+
+.sponsors__logo-link:hover,
+.sponsors__logo-link:focus-visible {
+  border-color: rgba(99, 102, 241, 0.45);
+  box-shadow: 0 18px 36px rgba(99, 102, 241, 0.25);
+  transform: translateY(-4px);
+}
+
+.sponsors__logo-link:hover .sponsors__logo,
+.sponsors__logo-link:focus-visible .sponsors__logo {
+  filter: grayscale(0%) saturate(1) brightness(1);
+  transform: scale(1.03);
+}
+
+@media (min-width: 960px) {
+  .sponsors {
+    grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+    align-items: start;
+  }
+
+  .sponsors__intro {
+    position: sticky;
+    top: 1.5rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .sponsors__intro {
+    text-align: center;
+  }
+
+  .sponsors__cta {
+    justify-self: center;
+  }
+}
+
+@media (max-width: 520px) {
+  .sponsors__logos {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sponsors__cta,
+  .sponsors__logo-link,
+  .sponsors__logo {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add sponsors section with grouped logos and sponsor pack CTA
- configure sponsor tiers and external links
- style the sponsors grid with monochrome logos that transition to color on hover

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f77a8add2c8323a6bca79c59e3f3fe