### PR TITLE
feat: add footer component with support details

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import Section from './components/Section.jsx';
+import Footer from './components/Footer.jsx';
 import Hero from './features/Hero/Hero.jsx';
 import Overview from './features/Overview/Overview.jsx';
 import Benefits from './features/Benefits/Benefits.jsx';
@@ -190,6 +191,7 @@ const App = () => {
           </Section>
         );
       })}
+      <Footer />
     </main>
   );
 };

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+const Footer = () => {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="footer" aria-labelledby="footer-title">
+      <div className="footer__content">
+        <div className="footer__brand" id="footer-title">
+          <span className="footer__brand-mark" aria-hidden="true">
+            YCS
+          </span>
+          <div className="footer__brand-text">
+            <span className="footer__brand-name">YarCyberSeason</span>
+            <p className="footer__brand-description">
+              Сообщество киберспорта Ярославской области
+            </p>
+          </div>
+        </div>
+        <div className="footer__links" aria-label="Контактная информация YarCyberSeason">
+          <div className="footer__section">
+            <h3 className="footer__section-title">Контакты</h3>
+            <ul className="footer__contact-list">
+              <li className="footer__contact-item">
+                <a className="footer__contact-link" href="tel:+74852999999">
+                  +7 (4852) 999-999
+                </a>
+              </li>
+              <li className="footer__contact-item">
+                <a className="footer__contact-link" href="mailto:team@yarseason.ru">
+                  team@yarseason.ru
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div className="footer__section">
+            <h3 className="footer__section-title">Поддержка</h3>
+            <a className="footer__link" href="#faq">
+              Часто задаваемые вопросы
+            </a>
+            <p className="footer__support-note">
+              Не нашли ответ? Напишите нам на почту — ответим в течение рабочего дня.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="footer__bottom">
+        <p className="footer__copyright">
+          © {currentYear} YarCyberSeason. Все права защищены.
+        </p>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3100,3 +3100,153 @@ main.app {
     transition: none;
   }
 }
+
+.footer {
+  margin-top: 4rem;
+  padding: 2.5rem 3rem 2rem;
+  border-radius: 1.5rem;
+  background: radial-gradient(circle at 10% 20%, rgba(96, 165, 250, 0.16), transparent 55%),
+    radial-gradient(circle at 90% 10%, rgba(168, 85, 247, 0.2), transparent 60%),
+    linear-gradient(150deg, #0f172a, #111827 65%, #1e293b);
+  color: #f8fafc;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+}
+
+.footer__content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.footer__brand {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  min-width: 220px;
+}
+
+.footer__brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 60px;
+  height: 60px;
+  border-radius: 1.2rem;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.9), rgba(168, 85, 247, 0.9));
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  color: #0b1120;
+  font-size: 1.25rem;
+  box-shadow: inset 0 0 18px rgba(255, 255, 255, 0.35);
+}
+
+.footer__brand-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.footer__brand-description {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.78);
+  line-height: 1.5;
+}
+
+.footer__links {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  flex: 1;
+}
+
+.footer__section-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(191, 219, 254, 0.95);
+}
+
+.footer__contact-list {
+  display: grid;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.footer__contact-link,
+.footer__link {
+  color: #bfdbfe;
+  font-weight: 500;
+  text-decoration: none;
+  font-size: 0.95rem;
+}
+
+.footer__contact-link:hover,
+.footer__contact-link:focus-visible,
+.footer__link:hover,
+.footer__link:focus-visible {
+  color: #f8fafc;
+  text-decoration: underline;
+}
+
+.footer__support-note {
+  margin: 0.75rem 0 0;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.72);
+  line-height: 1.6;
+}
+
+.footer__bottom {
+  margin-top: 2.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+  text-align: center;
+}
+
+.footer__copyright {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+@media (max-width: 640px) {
+  .footer {
+    padding: 2.25rem 1.75rem 1.75rem;
+  }
+
+  .footer__content {
+    gap: 1.75rem;
+  }
+
+  .footer__brand {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .footer__brand-mark {
+    width: 52px;
+    height: 52px;
+    border-radius: 1rem;
+    font-size: 1.1rem;
+  }
+
+  .footer__brand-description {
+    font-size: 0.85rem;
+  }
+
+  .footer__contact-link,
+  .footer__link {
+    font-size: 0.9rem;
+  }
+
+  .footer__copyright {
+    font-size: 0.8rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a branded footer component with contact details, FAQ link, and copyright notice
- integrate the footer into the main application layout after the content sections
- style the footer for readability, contrast, and responsive behaviour that matches the existing branding

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f77bedfae0832386609d16f85729c7