### PR TITLE
feat: add hero video background and key facts grid

### DIFF
--- a/src/features/Hero/config.json
+++ b/src/features/Hero/config.json
@@ -2,67 +2,147 @@
   "branding": {
     "tagline": "YCS CUP",
     "label": "YarCyberSeason",
+    "seasonLabel": "Сезон 2025/26",
     "links": [
-      { "label": "Формат", "href": "#format" },
-      { "label": "Правила", "href": "#rules" },
-      { "label": "Партнеры", "href": "#partners" }
+      { "label": "Календарь", "href": "#schedule" },
+      { "label": "Дивизионы", "href": "#divisions" },
+      { "label": "Партнёры", "href": "#sponsors" }
     ]
   },
-  "title": "CS2 vs Dota 2",
-  "subtitle": "Квалификации стартуют",
+  "primaryCta": {
+    "label": "Регистрация команды",
+    "href": "https://yarcyberseason.ru/register",
+    "ariaLabel": "Открыть форму регистрации команды YarCyberSeason 2025/26"
+  },
+  "title": "YarCyberSeason 2025/26",
+  "subtitle": "Новый сезон киберспортивных лиг для школьных, студенческих и открытых команд Центрального региона",
+  "media": {
+    "poster": "https://images.unsplash.com/photo-1542751371-adc38448a05e?auto=format&fit=crop&w=2000&q=80",
+    "fallbackImage": "https://images.unsplash.com/photo-1511512578047-dfb367046420?auto=format&fit=crop&w=2000&q=80",
+    "disableOnMobile": true,
+    "ariaLabel": "Видео-анонс нового сезона YarCyberSeason",
+    "sources": [
+      {
+        "src": "https://cdn.coverr.co/videos/coverr-futuristic-hacker-typing-4242/1080p.webm",
+        "type": "video/webm"
+      },
+      {
+        "src": "https://cdn.coverr.co/videos/coverr-futuristic-hacker-typing-4242/1080p.mp4",
+        "type": "video/mp4"
+      }
+    ]
+  },
   "background": {
-    "left": "https://images.unsplash.com/photo-1618005198919-d3d4b5a92eee?auto=format&fit=crop&w=900&q=80",
-    "right": "https://images.unsplash.com/photo-1618005198878-1fd66f39e7bb?auto=format&fit=crop&w=900&q=80"
+    "left": "https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1100&q=80",
+    "right": "https://images.unsplash.com/photo-1516905041604-7935af78f573?auto=format&fit=crop&w=1100&q=80"
   },
   "match": {
     "left": {
-      "code": "CS2",
-      "name": "Counter-Strike 2",
-      "note": "Best of 3, 5×5"
+      "code": "OPEN",
+      "name": "Открытая лига",
+      "note": "Онлайн-отборы осень 2025"
     },
     "right": {
-      "code": "Dota 2",
-      "name": "Defense of the Ancients",
-      "note": "Captain's Mode, 5×5"
+      "code": "LAN",
+      "name": "Гранд-финал",
+      "note": "Май 2026, Ярославль"
     }
   },
   "tabs": [
-    { "label": "CS2", "href": "#qual-cs2" },
-    { "label": "Dota 2", "href": "#qual-dota" }
+    { "label": "Открытая лига", "href": "#division-open" },
+    { "label": "Студенческий дивизион", "href": "#division-students" },
+    { "label": "Школьный дивизион", "href": "#division-school" }
   ],
-  "qualifiers": [
+  "keyFacts": [
     {
-      "tag": "CS2",
-      "title": "Квалификация CS2",
-      "description": "Онлайн-раунды, 24 октября, 19:00 МСК",
+      "tag": "OPEN",
+      "title": "Открытая лига",
+      "value": "Регистрация до 12 сентября",
+      "description": "Онлайн-отборочные раунды стартуют 15 сентября 2025 года. 256 слотов для полупрофессиональных составов.",
       "cta": {
-        "label": "Регистрация",
-        "href": "https://yarcyberseason.ru/register/cs2"
+        "label": "Регистрация OPEN",
+        "href": "https://yarcyberseason.ru/register/open",
+        "ariaLabel": "Зарегистрировать команду в открытой лиге"
       }
     },
     {
-      "tag": "Dota 2",
-      "title": "Квалификация Dota 2",
-      "description": "LAN-финал, 27 октября, 12:00 МСК",
+      "tag": "STUDENT",
+      "title": "Студенческий дивизион",
+      "value": "Регистрация до 19 сентября",
+      "description": "Кампус-лиги университетов региона. Отборочные стадии проходят в онлайн-формате, финал в декабре 2025 года.",
       "cta": {
-        "label": "Принять участие",
-        "href": "https://yarcyberseason.ru/register/dota2"
+        "label": "Регистрация STUDENT",
+        "href": "https://yarcyberseason.ru/register/student",
+        "ariaLabel": "Зарегистрировать команду студенческого дивизиона"
+      }
+    },
+    {
+      "tag": "SCHOOL",
+      "title": "Школьный дивизион",
+      "value": "Регистрация до 26 сентября",
+      "description": "Командные баталии для школьников 8-11 классов. Старт онлайн-групп — 29 сентября, финал в январе 2026 года.",
+      "cta": {
+        "label": "Регистрация SCHOOL",
+        "href": "https://yarcyberseason.ru/register/school",
+        "ariaLabel": "Зарегистрировать школьную команду"
+      }
+    },
+    {
+      "tag": "LAN",
+      "title": "Финальный фестиваль",
+      "value": "24 мая 2026",
+      "description": "Лучшие команды всех дивизионов встретятся на офлайн-сцене в Ярославле, чтобы побороться за кубок сезона и призовой фонд.",
+      "cta": {
+        "label": "Получить приглашение",
+        "href": "https://yarcyberseason.ru/final",
+        "ariaLabel": "Узнать подробнее о финальном фестивале"
+      }
+    }
+  ],
+  "qualifiers": [
+    {
+      "tag": "OPEN",
+      "title": "Онлайн-квалификация OPEN",
+      "description": "15–22 сентября 2025 • форматы CS2 и Dota 2",
+      "cta": {
+        "label": "Регистрация OPEN",
+        "href": "https://yarcyberseason.ru/register/open"
+      }
+    },
+    {
+      "tag": "STUDENT",
+      "title": "Кампус-лиги",
+      "description": "3–12 октября 2025 • гибридный формат с офлайн-плей-офф",
+      "cta": {
+        "label": "Заявка STUDENT",
+        "href": "https://yarcyberseason.ru/register/student"
+      }
+    },
+    {
+      "tag": "SCHOOL",
+      "title": "Школьные онлайн-группы",
+      "description": "29 сентября – 10 ноября 2025 • вечерние матчи",
+      "cta": {
+        "label": "Заявка SCHOOL",
+        "href": "https://yarcyberseason.ru/register/school"
       }
     }
   ],
   "prize": {
-    "label": "Призовой фонд",
-    "value": "500 000 ₽"
+    "label": "Призовой фонд сезона",
+    "value": "1 200 000 ₽"
   },
   "timer": {
-    "label": "До старта квалификации",
-    "deadline": "2024-10-24T19:00:00+03:00",
-    "expiredLabel": "Квалификация началась",
+    "label": "До старта сезона",
+    "deadline": "2025-09-15T18:00:00+03:00",
+    "expiredLabel": "Сезон начался",
     "fallbackLabel": "Следите за расписанием"
   },
   "logos": [
     "YCS",
     "CS2",
-    "Dota 2"
+    "Dota 2",
+    "Valorant",
+    "Rocket League"
   ]
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -349,15 +349,41 @@ main.app {
   inset: 0;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  opacity: 0.35;
+  overflow: hidden;
+  z-index: 0;
 }
 
 .hero__background-layer {
+  position: relative;
   background-size: cover;
   background-position: center;
-  filter: saturate(1.15) contrast(1.05);
+  filter: saturate(1.08) contrast(1.05);
   mix-blend-mode: screen;
+  opacity: 0.55;
+  z-index: 1;
 }
+.hero__background-video,
+.hero__background-fallback {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  width: 100%;
+  height: 100%;
+}
+
+.hero__background-video {
+  object-fit: cover;
+  filter: saturate(1.05) contrast(1.05);
+  opacity: 0.7;
+  z-index: 0;
+}
+
+.hero__background-fallback {
+  background-size: cover;
+  background-position: center;
+  filter: saturate(1.05) contrast(1.05);
+  z-index: 0;
+}
+
 
 .hero__overlay {
   position: absolute;
@@ -385,6 +411,48 @@ main.app {
   justify-content: space-between;
   gap: var(--space-3);
   align-items: center;
+}
+
+.hero__topnav {
+  display: flex;
+  align-items: center;
+}
+
+.hero__topnav-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.hero__topnav-item {
+  display: inline-flex;
+}
+
+.hero__topnav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  transition: background var(--transition-fast), color var(--transition-fast), border var(--transition-fast), transform var(--transition-fast);
+}
+
+.hero__topnav-link:hover,
+.hero__topnav-link:focus-visible {
+  background: var(--gradient-primary);
+  color: #05060f;
+  border-color: transparent;
+  transform: translateY(-1px);
 }
 
 .hero__brand {
@@ -439,6 +507,138 @@ main.app {
   color: var(--color-text-secondary);
   font-size: clamp(1.05rem, 0.9rem + 0.6vw, 1.25rem);
   max-width: 48ch;
+}
+
+.hero__centerpiece {
+  display: grid;
+  gap: clamp(var(--space-3), 2.5vw, var(--space-4));
+  max-width: min(780px, 100%);
+}
+
+.hero__season {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(64, 232, 194, 0.14);
+  color: var(--color-secondary);
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+}
+
+.hero__primary-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: var(--space-3);
+  padding: 0.75rem clamp(1.5rem, 4vw, 2.4rem);
+  border-radius: 999px;
+  background: var(--gradient-primary);
+  color: #05060f;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  text-decoration: none;
+  box-shadow: 0 18px 45px rgba(139, 123, 255, 0.35);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.hero__primary-cta:hover,
+.hero__primary-cta:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 26px 55px rgba(139, 123, 255, 0.45);
+}
+
+.hero__keyfacts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: clamp(var(--space-3), 3vw, var(--space-4));
+}
+
+.hero__keyfact {
+  position: relative;
+  padding: clamp(var(--space-4), 4vw, var(--space-5));
+  border-radius: var(--radius-xl);
+  background: rgba(15, 20, 42, 0.82);
+  border: 1px solid rgba(139, 123, 255, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  display: grid;
+  gap: var(--space-2);
+  overflow: hidden;
+}
+
+.hero__keyfact::after {
+  content: '';
+  position: absolute;
+  inset: auto -40% -40% auto;
+  width: 120px;
+  height: 120px;
+  background: radial-gradient(circle, rgba(139, 123, 255, 0.25), transparent 70%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.hero__keyfact-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(64, 232, 194, 0.18);
+  color: var(--color-secondary);
+  font-size: 0.7rem;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+}
+
+.hero__keyfact-title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.hero__keyfact-value {
+  margin: 0;
+  font-size: clamp(1.35rem, 1.15rem + 0.8vw, 1.8rem);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero__keyfact-description {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.hero__keyfact-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  margin-top: var(--space-2);
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  background: rgba(139, 123, 255, 0.18);
+  color: var(--color-text-primary);
+  text-decoration: none;
+  font-size: 0.85rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  transition: background var(--transition-fast), transform var(--transition-fast);
+}
+
+.hero__keyfact-cta:hover,
+.hero__keyfact-cta:focus-visible {
+  background: var(--gradient-primary);
+  color: #05060f;
+  transform: translateY(-2px);
 }
 
 .hero__matchup {
@@ -2247,6 +2447,10 @@ main.app {
   .app__logo {
     justify-content: center;
   }
+
+  .app__cta {
+    width: min(420px, 100%);
+  }
 }
 
 @media (max-width: 1024px) {
@@ -2269,6 +2473,14 @@ main.app {
 
   .hero__countdown-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero__keyfacts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero__primary-cta {
+    width: 100%;
   }
 
   .overview__layout,
@@ -2306,8 +2518,29 @@ main.app {
     padding: var(--space-3);
   }
 
+  .app__cta {
+    width: 100%;
+    margin-top: var(--space-3);
+  }
+
   .hero__inner {
     padding: clamp(var(--space-5), 8vw, var(--space-6));
+    gap: var(--space-4);
+  }
+
+  .hero__topbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
+  .hero__topnav {
+    width: 100%;
+  }
+
+  .hero__topnav-list {
+    width: 100%;
+    justify-content: flex-start;
   }
 
   .hero__tabs {
@@ -2315,11 +2548,20 @@ main.app {
     justify-content: center;
   }
 
+  .hero__primary-cta {
+    width: 100%;
+  }
+
+  .hero__keyfacts {
+    grid-template-columns: 1fr;
+  }
+
   .hero__qualifiers {
     grid-template-columns: 1fr;
   }
 
   .hero__countdown {
+    width: 100%;
     min-width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- add responsive hero video background with mobile fallback image and support for season CTA
- introduce divisional key facts grid and refresh hero configuration for the 2025/26 season
- update hero styling for media layers, key facts layout, and CTA responsiveness across breakpoints

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f7812bf11c832381a54b3ae3a86b79