### PR TITLE
feat: expand layout to full width

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -48,7 +48,7 @@
   --space-8: 3rem;
   --space-9: 4rem;
 
-  --max-width: 1180px;
+  --max-width: min(1600px, 96vw);
   --transition-fast: 120ms ease;
   --transition-normal: 220ms ease;
   --transition-slow: 420ms ease;
@@ -118,12 +118,20 @@ img {
 }
 
 main.app {
-  max-width: var(--max-width);
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   padding: clamp(var(--space-6), 4vw, var(--space-8)) clamp(var(--space-4), 4vw, var(--space-6)) var(--space-9);
   display: flex;
   flex-direction: column;
   gap: var(--space-7);
+  align-items: stretch;
+}
+
+.app__header,
+.footer {
+  width: 100%;
+  max-width: var(--max-width);
+  margin-inline: auto;
 }
 
 .app__header {
@@ -284,10 +292,16 @@ main.app {
   display: flex;
   flex-direction: column;
   gap: var(--space-5);
+  width: 100%;
+  max-width: var(--max-width);
+  margin-inline: auto;
 }
 
 .section__inner--full-bleed {
   padding: 0;
+  max-width: none;
+  width: 100%;
+  margin: 0;
 }
 
 .section__header {
@@ -2422,10 +2436,6 @@ main.app {
 }
 
 @media (min-width: 1280px) {
-  main.app {
-    max-width: 1280px;
-  }
-
   .hero__centerpiece {
     max-width: 760px;
   }


### PR DESCRIPTION
## Summary
- let the main layout stretch across the viewport while keeping responsive gutters
- center the header, footer, and section content with a wider adaptive max-width
- keep full-bleed sections edge-to-edge for hero-style blocks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f78460ba688323a122275c4dd14f86