### PR TITLE
feat: enrich YarCyberSeason news feed

### DIFF
--- a/src/features/News/News.css
+++ b/src/features/News/News.css
@@ -30,13 +30,56 @@
   transform: translateY(-4px);
 }
 
+.news__card {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.news__media {
+  display: block;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  line-height: 0;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+}
+
+.news__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform var(--transition-normal);
+}
+
+.news__media:focus-visible img,
+.news__media:hover img {
+  transform: scale(1.03);
+}
+
+.news__content {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.news__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+
+.news__source {
+  font-weight: 600;
+}
+
 .news__title {
-  margin: 0 0 var(--space-2);
+  margin: 0;
   font-size: 1.1rem;
 }
 
 .news__summary {
-  margin: 0 0 var(--space-3);
+  margin: 0;
   color: var(--color-text-secondary);
 }
 

--- a/src/features/News/News.jsx
+++ b/src/features/News/News.jsx
@@ -1,21 +1,64 @@
 import PropTypes from 'prop-types';
 import './News.css';
 
+const formatDate = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }).format(date);
+};
+
 const News = ({ data }) => (
   <div className="news">
     <h3 className="news__headline">{data.headline}</h3>
     <ul className="news__list">
-      {data.articles.map((article) => (
-        <li key={article.id} className="news__item">
-          <article>
-            <h4 className="news__title">{article.title}</h4>
-            <p className="news__summary">{article.summary}</p>
-            <a className="news__link" href={article.url} target="_blank" rel="noreferrer">
-              Read more
-            </a>
-          </article>
-        </li>
-      ))}
+      {data.articles.map((article) => {
+        const formattedDate = formatDate(article.publishedAt);
+
+        return (
+          <li key={article.id} className="news__item">
+            <article className="news__card">
+              {article.image && (
+                <a
+                  className="news__media"
+                  href={article.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={`Открыть материал «${article.title}»`}
+                >
+                  <img src={article.image} alt={article.title} loading="lazy" />
+                </a>
+              )}
+              <div className="news__content">
+                <div className="news__meta">
+                  {article.source && <span className="news__source">{article.source}</span>}
+                  {formattedDate && (
+                    <time className="news__date" dateTime={article.publishedAt}>
+                      {formattedDate}
+                    </time>
+                  )}
+                </div>
+                <h4 className="news__title">{article.title}</h4>
+                <p className="news__summary">{article.summary}</p>
+                <a className="news__link" href={article.url} target="_blank" rel="noreferrer">
+                  Читать материал
+                </a>
+              </div>
+            </article>
+          </li>
+        );
+      })}
     </ul>
   </div>
 );
@@ -29,6 +72,9 @@ News.propTypes = {
         title: PropTypes.string.isRequired,
         summary: PropTypes.string.isRequired,
         url: PropTypes.string.isRequired,
+        source: PropTypes.string,
+        publishedAt: PropTypes.string,
+        image: PropTypes.string,
       }),
     ).isRequired,
   }).isRequired,

--- a/src/features/News/config.json
+++ b/src/features/News/config.json
@@ -1,23 +1,41 @@
 {
-  "headline": "React Ecosystem Highlights",
+  "headline": "YarCyberSeason: актуальные новости турнира",
   "articles": [
     {
-      "id": "release",
-      "title": "React 18: Concurrent Features Simplified",
-      "summary": "The latest React release focuses on developer ergonomics and streaming rendering for modern apps.",
-      "url": "https://react.dev/blog"
+      "id": "match-previews",
+      "title": "Анонс матчей плей-офф YarCyberSeason",
+      "summary": "Представляем расписание решающих матчей с ключевыми противостояниями и ссылками на трансляции.",
+      "url": "https://yarcyberseason.ru/matches",
+      "source": "YarCyberSeason Media Center",
+      "publishedAt": "2024-07-12",
+      "image": "https://yarcyberseason.ru/assets/news/playoffs-lineup.jpg"
     },
     {
-      "id": "tooling",
-      "title": "Vite Becomes the Default Choice for SPA Tooling",
-      "summary": "Fast dev server, optimized builds, and first-class React support make Vite ideal for new projects.",
-      "url": "https://vitejs.dev/guide/"
+      "id": "qualifiers-wrap",
+      "title": "Итоги квалификаций: кто прошёл в основной этап",
+      "summary": "Результаты региональных отборов, неожиданные герои и статистика лучших игроков.",
+      "url": "https://yarcyberseason.ru/qualifiers-results",
+      "source": "YarCyberSeason Analytics",
+      "publishedAt": "2024-07-08",
+      "image": "https://yarcyberseason.ru/assets/news/qualifiers-recap.jpg"
     },
     {
-      "id": "community",
-      "title": "Component-driven Design Systems Grow",
-      "summary": "Teams adopt feature-based folders to scale SPA codebases while keeping components maintainable.",
-      "url": "https://storybook.js.org/blog/"
+      "id": "player-interview",
+      "title": "Интервью с капитаном команды Volga Rising",
+      "summary": "Как команда готовилась к сезону, планы на плей-офф и ожидания болельщиков.",
+      "url": "https://yarcyberseason.ru/interviews/volga-rising",
+      "source": "YarCyberSeason Live",
+      "publishedAt": "2024-07-05",
+      "image": "https://yarcyberseason.ru/assets/news/volga-rising-interview.jpg"
+    },
+    {
+      "id": "media-pack",
+      "title": "Медиапак YarCyberSeason: фото и хайлайты недели",
+      "summary": "Лучшие моменты, фото с арены и официальные заставки для социальных сетей.",
+      "url": "https://yarcyberseason.ru/media",
+      "source": "YarCyberSeason Production",
+      "publishedAt": "2024-07-03",
+      "image": "https://yarcyberseason.ru/assets/news/media-pack.jpg"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- replace the news configuration with YarCyberSeason-specific headline and stories including metadata for dates, sources, and imagery
- extend the News component to display the richer article content with formatted dates and media previews
- update styles so the news cards accommodate preview images and meta details

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7907c51e483239aeb9d194fd389d0