### PR TITLE
feat: convert header navigation to mobile hamburger menu

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -141,6 +141,51 @@ main.app {
   border-color: rgba(255, 255, 255, 0.18);
 }
 
+.app__menu-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+  padding: 0;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.app__menu-toggle:hover,
+.app__menu-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.app__menu-toggle-line {
+  display: block;
+  width: 22px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--color-text-primary);
+  transition: transform var(--transition-fast), opacity var(--transition-fast);
+}
+
+.app__menu-toggle-line + .app__menu-toggle-line {
+  margin-top: 5px;
+}
+
+.app__menu-toggle--open .app__menu-toggle-line:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.app__menu-toggle--open .app__menu-toggle-line:nth-child(2) {
+  opacity: 0;
+}
+
+.app__menu-toggle--open .app__menu-toggle-line:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
 @media (max-width: 1180px) {
   .app__header {
     grid-template-columns: 1fr;
@@ -167,11 +212,56 @@ main.app {
     top: 0;
     border-radius: var(--radius-lg);
     padding: var(--space-3);
+    grid-template-columns: auto auto;
+    grid-template-areas:
+      'logo toggle'
+      'nav nav'
+      'cta cta';
+    align-items: center;
+    justify-items: stretch;
+    row-gap: var(--space-3);
   }
 
   .app__cta {
     width: 100%;
     margin-top: var(--space-3);
+    grid-area: cta;
+  }
+
+  .app__logo {
+    grid-area: logo;
+    justify-self: flex-start;
+  }
+
+  .app__menu-toggle {
+    display: inline-flex;
+    grid-area: toggle;
+    justify-self: end;
+  }
+
+  .app__nav {
+    display: none;
+    grid-area: nav;
+    width: 100%;
+    padding: var(--space-3);
+    background: linear-gradient(140deg, rgba(18, 25, 48, 0.95), rgba(24, 36, 69, 0.92));
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(139, 123, 255, 0.25);
+    box-shadow: 0 16px 36px rgba(5, 9, 24, 0.6);
+  }
+
+  .app__nav--open {
+    display: block;
+  }
+
+  .app__nav-list {
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .app__nav-link {
+    width: 100%;
+    justify-content: flex-start;
   }
 }
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import Section from './components/Section.jsx';
 import Footer from './components/Footer.jsx';
 import Hero from './features/Hero/Hero.jsx';
@@ -145,6 +147,30 @@ const App = () => {
       label: section.navLabel,
     }));
 
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth > 768 && isMenuOpen) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [isMenuOpen]);
+
+  const toggleMenu = () => {
+    setIsMenuOpen((prev) => !prev);
+  };
+
+  const handleNavLinkClick = () => {
+    setIsMenuOpen(false);
+  };
+
   return (
     <main className="app">
       <header className="app__header">
@@ -154,11 +180,27 @@ const App = () => {
           </span>
           <span className="app__logo-text">YarCyberSeason</span>
         </a>
-        <nav className="app__nav" aria-label="Навигация по секциям YarCyberSeason">
+        <button
+          type="button"
+          className={`app__menu-toggle${isMenuOpen ? ' app__menu-toggle--open' : ''}`}
+          aria-label={isMenuOpen ? 'Скрыть меню' : 'Открыть меню'}
+          aria-expanded={isMenuOpen}
+          aria-controls="app-navigation"
+          onClick={toggleMenu}
+        >
+          <span className="app__menu-toggle-line" aria-hidden="true" />
+          <span className="app__menu-toggle-line" aria-hidden="true" />
+          <span className="app__menu-toggle-line" aria-hidden="true" />
+        </button>
+        <nav
+          id="app-navigation"
+          className={`app__nav${isMenuOpen ? ' app__nav--open' : ''}`}
+          aria-label="Навигация по секциям YarCyberSeason"
+        >
           <ul className="app__nav-list">
             {navigationItems.map(({ id, label }) => (
               <li key={id} className="app__nav-item">
-                <a className="app__nav-link" href={`#${id}`}>
+                <a className="app__nav-link" href={`#${id}`} onClick={handleNavLinkClick}>
                   {label}
                 </a>
               </li>


### PR DESCRIPTION
## Summary
- add responsive hamburger toggle for the main navigation when viewed on mobile devices
- update header layout and styling to support collapsible menu presentation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7904793c48323b7fcde5b26f30fe1