### PR TITLE
Refresh hero and sponsors styling

### DIFF
--- a/src/features/Hero/Hero.css
+++ b/src/features/Hero/Hero.css
@@ -71,6 +71,116 @@
   gap: clamp(var(--space-5), 5vw, var(--space-7));
 }
 
+.hero__display {
+  font-size: clamp(2.9rem, 2.2rem + 3vw, 4.4rem);
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  line-height: 1.05;
+  text-wrap: balance;
+}
+
+.hero__display-subtitle {
+  font-size: clamp(1.12rem, 0.95rem + 0.9vw, 1.6rem);
+  color: var(--color-text-secondary);
+  letter-spacing: -0.005em;
+  line-height: 1.55;
+  max-width: min(60ch, 100%);
+  text-wrap: pretty;
+}
+
+.hero__display-lead {
+  font-size: clamp(1.05rem, 0.9rem + 0.8vw, 1.45rem);
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  text-shadow: 0 6px 16px rgba(9, 14, 32, 0.45);
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.4rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  border: 1px solid rgba(139, 123, 255, 0.22);
+  background: rgba(139, 123, 255, 0.12);
+  color: var(--color-text-secondary);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(18px);
+  transition: background var(--transition-normal), color var(--transition-normal),
+    border var(--transition-normal), box-shadow var(--transition-normal);
+}
+
+.hero__badge--accent {
+  background: rgba(64, 232, 194, 0.18);
+  border-color: rgba(64, 232, 194, 0.35);
+  color: var(--color-secondary);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 8px 18px rgba(64, 232, 194, 0.25);
+}
+
+.hero__badge--soft {
+  background: rgba(139, 123, 255, 0.14);
+  border-color: rgba(139, 123, 255, 0.32);
+  color: var(--color-text-primary);
+}
+
+.hero__badge--outline {
+  background: rgba(9, 14, 32, 0.45);
+  border-color: rgba(139, 123, 255, 0.28);
+  color: var(--color-text-secondary);
+}
+
+.hero__glass {
+  position: relative;
+  border-radius: clamp(1.4rem, 2.4vw, 2.4rem);
+  background: rgba(10, 14, 30, 0.7);
+  border: 1px solid rgba(139, 123, 255, 0.22);
+  box-shadow: 0 26px 60px rgba(5, 9, 26, 0.45);
+  backdrop-filter: blur(22px);
+  transition: background var(--transition-normal), border var(--transition-normal),
+    box-shadow var(--transition-normal), transform var(--transition-fast);
+  overflow: hidden;
+}
+
+.hero__glass::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 15%, rgba(255, 255, 255, 0.12), transparent 60%),
+    radial-gradient(circle at 85% 20%, rgba(64, 232, 194, 0.18), transparent 65%);
+  opacity: 0.45;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  transition: opacity var(--transition-normal);
+}
+
+.hero__glass:hover,
+.hero__glass:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 32px 70px rgba(6, 12, 36, 0.55);
+  border-color: rgba(139, 123, 255, 0.4);
+}
+
+.hero__glass:hover::before,
+.hero__glass:focus-within::before {
+  opacity: 0.72;
+}
+
+.hero__glass--strong {
+  background: linear-gradient(140deg, rgba(12, 18, 36, 0.82), rgba(26, 30, 58, 0.85));
+  border-color: rgba(139, 123, 255, 0.35);
+}
+
+.hero__glass--soft {
+  background: linear-gradient(155deg, rgba(15, 22, 42, 0.68), rgba(22, 32, 58, 0.72));
+}
+
 .hero__topbar {
   display: flex;
   flex-wrap: wrap;
@@ -164,16 +274,12 @@
 
 .hero__title {
   margin: 0;
-  font-size: clamp(2.4rem, 1.6rem + 2vw, 3.2rem);
-  font-weight: 800;
-  letter-spacing: -0.02em;
+  color: var(--color-text-primary);
 }
 
 .hero__subtitle {
   margin: 0;
-  color: var(--color-text-secondary);
-  font-size: clamp(1.05rem, 0.9rem + 0.6vw, 1.25rem);
-  max-width: 48ch;
+  color: inherit;
 }
 
 .hero__centerpiece {
@@ -183,16 +289,7 @@
 }
 
 .hero__season {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  background: rgba(64, 232, 194, 0.14);
-  color: var(--color-secondary);
-  font-size: 0.75rem;
-  letter-spacing: 0.28em;
-  text-transform: uppercase;
+  letter-spacing: 0.32em;
 }
 
 .hero__primary-cta {
@@ -229,9 +326,6 @@
   position: relative;
   padding: clamp(var(--space-4), 4vw, var(--space-5));
   border-radius: var(--radius-xl);
-  background: rgba(15, 20, 42, 0.82);
-  border: 1px solid rgba(139, 123, 255, 0.2);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
   display: grid;
   gap: var(--space-2);
   overflow: hidden;
@@ -243,22 +337,13 @@
   inset: auto -40% -40% auto;
   width: 120px;
   height: 120px;
-  background: radial-gradient(circle, rgba(139, 123, 255, 0.25), transparent 70%);
-  opacity: 0.6;
+  background: radial-gradient(circle, rgba(139, 123, 255, 0.32), transparent 70%);
+  opacity: 0.45;
   pointer-events: none;
 }
 
 .hero__keyfact-tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.65rem;
-  border-radius: 999px;
-  background: rgba(64, 232, 194, 0.18);
-  color: var(--color-secondary);
-  font-size: 0.7rem;
   letter-spacing: 0.26em;
-  text-transform: uppercase;
 }
 
 .hero__keyfact-title {
@@ -315,9 +400,6 @@
   gap: var(--space-4);
   padding: var(--space-3);
   border-radius: var(--radius-lg);
-  background: rgba(8, 12, 28, 0.65);
-  border: 1px solid rgba(139, 123, 255, 0.24);
-  backdrop-filter: blur(12px);
 }
 
 .hero__match-side {
@@ -398,8 +480,6 @@
   position: relative;
   padding: var(--space-4);
   border-radius: var(--radius-lg);
-  background: var(--color-card);
-  border: 1px solid rgba(139, 123, 255, 0.18);
   overflow: hidden;
 }
 
@@ -419,16 +499,7 @@
 }
 
 .hero__qualifier-tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.65rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
   letter-spacing: 0.25em;
-  text-transform: uppercase;
-  background: rgba(64, 232, 194, 0.12);
-  color: var(--color-secondary);
 }
 
 .hero__qualifier-title {

--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -192,10 +192,16 @@ const Hero = ({ data }) => {
         </header>
 
         <div className="hero__centerpiece">
-          {branding?.seasonLabel ? <span className="hero__season">{branding.seasonLabel}</span> : null}
-          {branding?.tagline ? <span className="hero__tagline">{branding.tagline}</span> : null}
-          <h1 className="hero__title">{title}</h1>
-          <p className="hero__subtitle">{subtitle}</p>
+          {branding?.seasonLabel ? (
+            <span className="hero__season hero__badge hero__badge--accent">
+              {branding.seasonLabel}
+            </span>
+          ) : null}
+          {branding?.tagline ? (
+            <span className="hero__tagline hero__display-lead">{branding.tagline}</span>
+          ) : null}
+          <h1 className="hero__title hero__display">{title}</h1>
+          <p className="hero__subtitle hero__display-subtitle">{subtitle}</p>
 
           {primaryCta ? (
             <a
@@ -208,7 +214,11 @@ const Hero = ({ data }) => {
           ) : null}
 
           {match ? (
-            <div className="hero__matchup" role="group" aria-label="Противостояние игр">
+            <div
+              className="hero__matchup hero__glass hero__glass--strong"
+              role="group"
+              aria-label="Противостояние игр"
+            >
               {match.left ? (
                 <div className="hero__match-side hero__match-side--left">
                   <span className="hero__match-code">{match.left.code}</span>
@@ -243,8 +253,14 @@ const Hero = ({ data }) => {
         {Array.isArray(keyFacts) && keyFacts.length > 0 ? (
           <div className="hero__keyfacts" role="list">
             {keyFacts.map((fact) => (
-              <article key={fact.title} className="hero__keyfact" role="listitem">
-                {fact.tag ? <span className="hero__keyfact-tag">{fact.tag}</span> : null}
+              <article
+                key={fact.title}
+                className="hero__keyfact hero__glass"
+                role="listitem"
+              >
+                {fact.tag ? (
+                  <span className="hero__keyfact-tag hero__badge hero__badge--soft">{fact.tag}</span>
+                ) : null}
                 <h2 className="hero__keyfact-title">{fact.title}</h2>
                 {fact.value ? <p className="hero__keyfact-value">{fact.value}</p> : null}
                 {fact.description ? <p className="hero__keyfact-description">{fact.description}</p> : null}
@@ -265,8 +281,16 @@ const Hero = ({ data }) => {
         {Array.isArray(qualifiers) && qualifiers.length > 0 ? (
           <div className="hero__qualifiers" role="list">
             {qualifiers.map((qualifier) => (
-              <article key={qualifier.title} className="hero__qualifier" role="listitem">
-                {qualifier.tag ? <span className="hero__qualifier-tag">{qualifier.tag}</span> : null}
+              <article
+                key={qualifier.title}
+                className="hero__qualifier hero__glass hero__glass--soft"
+                role="listitem"
+              >
+                {qualifier.tag ? (
+                  <span className="hero__qualifier-tag hero__badge hero__badge--outline">
+                    {qualifier.tag}
+                  </span>
+                ) : null}
                 <h2 className="hero__qualifier-title">{qualifier.title}</h2>
                 {qualifier.description ? <p className="hero__qualifier-description">{qualifier.description}</p> : null}
                 {qualifier.cta ? (

--- a/src/features/Sponsors/Sponsors.css
+++ b/src/features/Sponsors/Sponsors.css
@@ -1,6 +1,53 @@
 .sponsors {
+  --sponsors-surface: rgba(18, 24, 52, 0.8);
+  --sponsors-surface-strong: rgba(26, 34, 68, 0.86);
+  --sponsors-featured-surface: linear-gradient(140deg, rgba(82, 45, 176, 0.78), rgba(35, 86, 196, 0.82));
+  --sponsors-border: rgba(139, 123, 255, 0.26);
+  --sponsors-border-strong: rgba(139, 123, 255, 0.38);
+  --sponsors-shadow: 0 48px 120px rgba(5, 9, 30, 0.55);
+  --sponsors-text-primary: var(--color-text-primary);
+  --sponsors-text-secondary: rgba(199, 210, 243, 0.88);
+  --sponsors-text-muted: rgba(148, 163, 199, 0.78);
+  --sponsors-logo-bg: rgba(8, 12, 28, 0.7);
+  --sponsors-logo-bg-strong: rgba(11, 16, 34, 0.82);
+  position: relative;
   display: grid;
-  gap: var(--space-6);
+  gap: clamp(var(--space-5), 4vw, var(--space-6));
+  padding: clamp(var(--space-5), 6vw, var(--space-7));
+  border-radius: clamp(2rem, 4vw, 3.2rem);
+  background:
+    radial-gradient(circle at 12% 18%, rgba(139, 123, 255, 0.34), transparent 55%),
+    radial-gradient(circle at 82% 12%, rgba(64, 232, 194, 0.24), transparent 60%),
+    linear-gradient(165deg, rgba(9, 14, 32, 0.94), rgba(16, 24, 48, 0.88));
+  border: 1px solid var(--sponsors-border);
+  box-shadow: var(--sponsors-shadow);
+  overflow: hidden;
+  isolation: isolate;
+  color: var(--sponsors-text-primary);
+}
+
+.sponsors::before {
+  content: '';
+  position: absolute;
+  inset: -25% -35%;
+  background:
+    radial-gradient(circle at 30% 20%, rgba(139, 123, 255, 0.45), transparent 55%),
+    radial-gradient(circle at 70% 80%, rgba(64, 232, 194, 0.26), transparent 62%),
+    linear-gradient(120deg, rgba(76, 29, 149, 0.32), transparent 60%);
+  opacity: 0.7;
+  filter: blur(0);
+  pointer-events: none;
+}
+
+.sponsors::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(180deg, rgba(9, 12, 28, 0.4), transparent 45%, rgba(9, 12, 28, 0.65) 100%),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.02) 1px, transparent 1px, transparent 12px);
+  opacity: 0.9;
+  pointer-events: none;
 }
 
 .sponsors__intro {
@@ -18,33 +65,86 @@
 
 .sponsors__description {
   margin: 0;
-  color: var(--color-text-secondary);
+  color: var(--sponsors-text-secondary);
+  font-size: 1rem;
+  line-height: 1.7;
 }
 
 .sponsors__cta {
   justify-self: flex-start;
   display: inline-flex;
-  padding: 0.75rem 1.6rem;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.8rem 1.75rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.08);
-  color: var(--color-text-primary);
+  color: var(--sponsors-text-primary);
   text-decoration: none;
-  transition: transform var(--transition-fast), background var(--transition-fast);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+  box-shadow: 0 18px 48px rgba(9, 14, 32, 0.4);
+  backdrop-filter: blur(14px);
+  transition: transform var(--transition-fast), background var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 
 .sponsors__cta:hover,
 .sponsors__cta:focus-visible {
-  transform: translateY(-2px);
+  transform: translateY(-3px);
   background: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 26px 64px rgba(9, 14, 32, 0.55);
+}
+
+.sponsors__panel {
+  position: relative;
+  display: grid;
+  gap: clamp(var(--space-3), 2.5vw, var(--space-4));
+  padding: clamp(1.8rem, 4vw, 3rem);
+  border-radius: clamp(1.8rem, 3vw, 2.8rem);
+  background: var(--sponsors-surface);
+  border: 1px solid var(--sponsors-border);
+  box-shadow: 0 28px 72px rgba(5, 9, 32, 0.45);
+  backdrop-filter: blur(22px);
+  overflow: hidden;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast),
+    border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.sponsors__panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 15% 15%, rgba(139, 123, 255, 0.25), transparent 55%),
+    radial-gradient(circle at 85% 20%, rgba(64, 232, 194, 0.22), transparent 55%);
+  opacity: 0.4;
+  pointer-events: none;
+  transition: opacity var(--transition-normal);
+}
+
+.sponsors__panel:hover,
+.sponsors__panel:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 36px 88px rgba(5, 9, 32, 0.6);
+  border-color: var(--sponsors-border-strong);
+}
+
+.sponsors__panel:hover::before,
+.sponsors__panel:focus-within::before {
+  opacity: 0.7;
 }
 
 .sponsors__featured {
-  display: grid;
-  gap: var(--space-5);
-  padding: clamp(1.5rem, 4vw, 3rem);
-  border-radius: var(--radius-2xl);
-  background: linear-gradient(135deg, rgba(76, 29, 149, 0.42), rgba(30, 64, 175, 0.65));
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: var(--sponsors-featured-surface);
+  color: var(--sponsors-text-primary);
+  gap: clamp(var(--space-4), 3vw, var(--space-5));
+}
+
+.sponsors__featured::before {
+  background:
+    radial-gradient(circle at 25% 20%, rgba(255, 255, 255, 0.15), transparent 58%),
+    radial-gradient(circle at 80% 70%, rgba(255, 111, 207, 0.24), transparent 65%);
 }
 
 .sponsors__featured-content {
@@ -54,15 +154,16 @@
 
 .sponsors__featured-title {
   margin: 0;
-  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-size: clamp(1.9rem, 2.5vw, 2.8rem);
   font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
 .sponsors__featured-description {
   margin: 0;
-  color: var(--color-text-secondary);
+  color: var(--sponsors-text-secondary);
   font-size: 1rem;
-  line-height: 1.6;
+  line-height: 1.7;
 }
 
 .sponsors__featured-highlights {
@@ -75,20 +176,21 @@
 
 .sponsors__featured-highlight {
   position: relative;
-  padding-left: 1.4rem;
-  font-size: 0.95rem;
-  color: var(--color-text-secondary);
+  padding-left: 1.6rem;
+  font-size: 0.98rem;
+  color: var(--sponsors-text-secondary);
 }
 
 .sponsors__featured-highlight::before {
   content: '';
   position: absolute;
   left: 0;
-  top: 0.45rem;
-  width: 0.6rem;
-  height: 0.6rem;
+  top: 0.4rem;
+  width: 0.65rem;
+  height: 0.65rem;
   border-radius: 999px;
-  background: var(--color-accent);
+  background: linear-gradient(135deg, rgba(64, 232, 194, 0.95), rgba(139, 123, 255, 0.95));
+  box-shadow: 0 0 12px rgba(64, 232, 194, 0.45);
 }
 
 .sponsors__featured-stats {
@@ -100,19 +202,19 @@
 
 .sponsors__featured-stat {
   display: grid;
-  gap: 0.25rem;
+  gap: 0.3rem;
 }
 
 .sponsors__featured-stat-value {
   margin: 0;
-  font-size: clamp(1.4rem, 3vw, 2.2rem);
+  font-size: clamp(1.4rem, 2.2vw, 2.4rem);
   font-weight: 700;
-  color: var(--color-text-primary);
+  color: var(--sponsors-text-primary);
 }
 
 .sponsors__featured-stat-label {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: rgba(255, 255, 255, 0.72);
@@ -125,17 +227,20 @@
   gap: var(--space-2);
   padding: 0.9rem 1.8rem;
   border-radius: 999px;
-  background: var(--color-accent);
-  color: var(--color-text-on-accent, #050505);
+  background: var(--gradient-primary);
+  color: #05060f;
   text-decoration: none;
   font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  box-shadow: 0 24px 60px rgba(139, 123, 255, 0.3);
   transition: transform var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .sponsors__featured-cta:hover,
 .sponsors__featured-cta:focus-visible {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.24);
+  transform: translateY(-3px);
+  box-shadow: 0 28px 70px rgba(139, 123, 255, 0.4);
 }
 
 .sponsors__featured-logos {
@@ -148,40 +253,82 @@
   align-items: stretch;
 }
 
-.sponsors__featured-logo-item {
+.sponsors__logo-spot {
+  position: relative;
   display: flex;
+  border-radius: clamp(1.4rem, 2.5vw, 2rem);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.sponsors__logo-spot::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.12), transparent 60%);
+  opacity: 0.25;
+  pointer-events: none;
+  transition: opacity var(--transition-normal);
+}
+
+.sponsors__logo-tile {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: clamp(1.2rem, 3vw, 2rem);
-  border-radius: var(--radius-xl);
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  width: 100%;
+  padding: clamp(1.1rem, 3vw, 2.1rem);
+  border-radius: inherit;
+  text-decoration: none;
+  color: var(--sponsors-text-secondary);
+  background: var(--sponsors-logo-bg);
+  border: 1px solid rgba(139, 123, 255, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 18px 40px rgba(5, 9, 32, 0.4);
+  backdrop-filter: blur(16px);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast),
+    border var(--transition-fast), background var(--transition-fast);
+}
+
+.sponsors__logo-spot:hover::before,
+.sponsors__logo-spot:focus-within::before {
+  opacity: 0.55;
+}
+
+.sponsors__logo-spot:hover .sponsors__logo-tile,
+.sponsors__logo-spot:focus-within .sponsors__logo-tile,
+.sponsors__logo-tile:focus-visible {
+  transform: translateY(-3px);
+  background: var(--sponsors-logo-bg-strong);
+  border-color: rgba(139, 123, 255, 0.42);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 28px 64px rgba(5, 9, 32, 0.55);
+}
+
+.sponsors__logo-spot:focus-within .sponsors__logo-tile,
+.sponsors__logo-tile:focus-visible {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 4px;
 }
 
 .sponsors__featured-logo-link,
-.sponsors__featured-logo-static {
-  display: flex;
+.sponsors__featured-logo-static,
+.sponsors__logo-link,
+.sponsors__logo-static {
   width: 100%;
-  height: 100%;
-  align-items: center;
-  justify-content: center;
-  text-decoration: none;
 }
 
-.sponsors__featured-logo-link:hover,
-.sponsors__featured-logo-link:focus-visible {
-  transform: translateY(-2px);
-}
-
-.sponsors__featured-logo-link {
-  transition: transform var(--transition-fast);
-}
-
-.sponsors__featured-logo-image {
-  width: min(100%, 220px);
-  max-height: 120px;
+.sponsors__featured-logo-image,
+.sponsors__logo {
+  width: 100%;
+  max-width: clamp(140px, 24vw, 220px);
+  max-height: clamp(56px, 10vw, 120px);
   object-fit: contain;
-  filter: grayscale(0.2);
+  filter: saturate(1.05) contrast(1.05);
+  transition: filter var(--transition-fast), transform var(--transition-fast);
+}
+
+.sponsors__logo-spot:hover img,
+.sponsors__logo-spot:focus-within img {
+  filter: saturate(1.15) contrast(1.08) brightness(1.02);
+  transform: scale(1.03);
 }
 
 .sponsors__tiers {
@@ -190,12 +337,7 @@
 }
 
 .sponsors__tier {
-  display: grid;
-  gap: var(--space-3);
-  padding: var(--space-4);
-  border-radius: var(--radius-xl);
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  gap: clamp(var(--space-3), 2.5vw, var(--space-4));
 }
 
 .sponsors__tier-header {
@@ -205,12 +347,15 @@
 
 .sponsors__tier-title {
   margin: 0;
-  font-size: 1.2rem;
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--sponsors-text-primary);
 }
 
 .sponsors__tier-description {
   margin: 0;
-  color: var(--color-text-secondary);
+  color: var(--sponsors-text-secondary);
+  line-height: 1.6;
 }
 
 .sponsors__tier-highlights {
@@ -218,7 +363,7 @@
   gap: 0.5rem;
   margin: 0;
   padding-left: 1.2rem;
-  color: var(--color-text-secondary);
+  color: var(--sponsors-text-secondary);
 }
 
 .sponsors__tier-stats {
@@ -236,8 +381,8 @@
 .sponsors__tier-stat-value {
   margin: 0;
   font-weight: 600;
-  font-size: 1.1rem;
-  color: var(--color-text-primary);
+  font-size: 1.15rem;
+  color: var(--sponsors-text-primary);
 }
 
 .sponsors__tier-stat-label {
@@ -245,7 +390,7 @@
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(255, 255, 255, 0.6);
+  color: rgba(255, 255, 255, 0.66);
 }
 
 .sponsors__logos {
@@ -255,49 +400,7 @@
   display: grid;
   gap: var(--space-3);
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  align-items: center;
-}
-
-.sponsors__logo-item {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--space-3);
-  border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.sponsors__logo-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  padding: var(--space-3);
-  border-radius: var(--radius-lg);
-  text-decoration: none;
-  color: var(--color-text-secondary);
-  transition: transform var(--transition-fast);
-}
-
-.sponsors__logo-link:hover,
-.sponsors__logo-link:focus-visible {
-  transform: translateY(-2px);
-}
-
-.sponsors__logo-static {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  padding: var(--space-3);
-  border-radius: var(--radius-lg);
-}
-
-.sponsors__logo {
-  width: min(100%, 180px);
-  max-height: 80px;
-  object-fit: contain;
+  align-items: stretch;
 }
 
 @media (min-width: 1024px) {
@@ -310,5 +413,84 @@
 @media (min-width: 1280px) {
   .sponsors__logos {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+:root[data-theme='light'] .sponsors,
+[data-theme='light'] .sponsors {
+  --sponsors-surface: rgba(245, 247, 255, 0.9);
+  --sponsors-surface-strong: rgba(231, 238, 255, 0.92);
+  --sponsors-featured-surface: linear-gradient(140deg, rgba(255, 255, 255, 0.95), rgba(229, 236, 255, 0.92));
+  --sponsors-border: rgba(99, 111, 209, 0.2);
+  --sponsors-border-strong: rgba(99, 111, 209, 0.34);
+  --sponsors-shadow: 0 40px 90px rgba(20, 30, 70, 0.18);
+  --sponsors-text-primary: #111534;
+  --sponsors-text-secondary: rgba(35, 45, 80, 0.78);
+  --sponsors-text-muted: rgba(70, 82, 112, 0.7);
+  --sponsors-logo-bg: rgba(12, 18, 40, 0.88);
+  --sponsors-logo-bg-strong: rgba(12, 18, 40, 0.94);
+  color: var(--sponsors-text-primary);
+  background:
+    radial-gradient(circle at 20% 20%, rgba(160, 166, 255, 0.32), transparent 60%),
+    radial-gradient(circle at 80% 0%, rgba(142, 225, 255, 0.2), transparent 60%),
+    linear-gradient(165deg, rgba(242, 244, 255, 0.95), rgba(225, 232, 255, 0.92));
+}
+
+:root[data-theme='light'] .sponsors__description,
+[data-theme='light'] .sponsors__description,
+:root[data-theme='light'] .sponsors__tier-description,
+[data-theme='light'] .sponsors__tier-description,
+:root[data-theme='light'] .sponsors__tier-highlights,
+[data-theme='light'] .sponsors__tier-highlights {
+  color: var(--sponsors-text-secondary);
+}
+
+:root[data-theme='light'] .sponsors__featured-stat-label,
+[data-theme='light'] .sponsors__featured-stat-label,
+:root[data-theme='light'] .sponsors__tier-stat-label,
+[data-theme='light'] .sponsors__tier-stat-label {
+  color: rgba(32, 42, 78, 0.55);
+}
+
+:root[data-theme='light'] .sponsors__logo,
+[data-theme='light'] .sponsors__logo,
+:root[data-theme='light'] .sponsors__featured-logo-image,
+[data-theme='light'] .sponsors__featured-logo-image {
+  filter: brightness(1.05) contrast(1.12) saturate(1.05);
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme='dark']) .sponsors {
+    --sponsors-surface: rgba(245, 247, 255, 0.9);
+    --sponsors-surface-strong: rgba(231, 238, 255, 0.92);
+    --sponsors-featured-surface: linear-gradient(140deg, rgba(255, 255, 255, 0.95), rgba(229, 236, 255, 0.92));
+    --sponsors-border: rgba(99, 111, 209, 0.2);
+    --sponsors-border-strong: rgba(99, 111, 209, 0.34);
+    --sponsors-shadow: 0 40px 90px rgba(20, 30, 70, 0.18);
+    --sponsors-text-primary: #111534;
+    --sponsors-text-secondary: rgba(35, 45, 80, 0.78);
+    --sponsors-text-muted: rgba(70, 82, 112, 0.7);
+    --sponsors-logo-bg: rgba(12, 18, 40, 0.88);
+    --sponsors-logo-bg-strong: rgba(12, 18, 40, 0.94);
+    background:
+      radial-gradient(circle at 20% 20%, rgba(160, 166, 255, 0.32), transparent 60%),
+      radial-gradient(circle at 80% 0%, rgba(142, 225, 255, 0.2), transparent 60%),
+      linear-gradient(165deg, rgba(242, 244, 255, 0.95), rgba(225, 232, 255, 0.92));
+  }
+
+  :root:not([data-theme='dark']) .sponsors__description,
+  :root:not([data-theme='dark']) .sponsors__tier-description,
+  :root:not([data-theme='dark']) .sponsors__tier-highlights {
+    color: var(--sponsors-text-secondary);
+  }
+
+  :root:not([data-theme='dark']) .sponsors__featured-stat-label,
+  :root:not([data-theme='dark']) .sponsors__tier-stat-label {
+    color: rgba(32, 42, 78, 0.55);
+  }
+
+  :root:not([data-theme='dark']) .sponsors__logo,
+  :root:not([data-theme='dark']) .sponsors__featured-logo-image {
+    filter: brightness(1.05) contrast(1.12) saturate(1.05);
   }
 }

--- a/src/features/Sponsors/Sponsors.jsx
+++ b/src/features/Sponsors/Sponsors.jsx
@@ -42,7 +42,7 @@ const Sponsors = ({ data }) => {
 
       {featuredTier ? (
         <section
-          className="sponsors__featured"
+          className="sponsors__featured sponsors__panel sponsors__panel--featured"
           aria-labelledby={`${featuredTier.id}-heading`}
         >
           <div className="sponsors__featured-content">
@@ -91,10 +91,13 @@ const Sponsors = ({ data }) => {
           {featuredSponsors.length ? (
             <ul className="sponsors__featured-logos">
               {featuredSponsors.map((sponsor) => (
-                <li key={sponsor.name} className="sponsors__featured-logo-item">
+                <li
+                  key={sponsor.name}
+                  className="sponsors__featured-logo-item sponsors__logo-spot"
+                >
                   {sponsor?.url ? (
                     <a
-                      className="sponsors__featured-logo-link"
+                      className="sponsors__featured-logo-link sponsors__logo-tile"
                       href={sponsor.url}
                       target="_blank"
                       rel="noreferrer"
@@ -108,7 +111,7 @@ const Sponsors = ({ data }) => {
                       />
                     </a>
                   ) : (
-                    <div className="sponsors__featured-logo-static">
+                    <div className="sponsors__featured-logo-static sponsors__logo-tile">
                       <img
                         className="sponsors__featured-logo-image"
                         src={sponsor.logo}
@@ -129,7 +132,7 @@ const Sponsors = ({ data }) => {
           {regularTiersWithSponsors.map((tier) => (
             <section
               key={tier.id}
-              className="sponsors__tier"
+              className="sponsors__tier sponsors__panel"
               aria-labelledby={`${tier.id}-heading`}
             >
               <div className="sponsors__tier-header">
@@ -166,10 +169,13 @@ const Sponsors = ({ data }) => {
                   const hasLink = Boolean(sponsor?.url);
 
                   return (
-                    <li key={sponsor.name} className="sponsors__logo-item">
+                    <li
+                      key={sponsor.name}
+                      className="sponsors__logo-item sponsors__logo-spot"
+                    >
                       {hasLink ? (
                         <a
-                          className="sponsors__logo-link"
+                          className="sponsors__logo-link sponsors__logo-tile"
                           href={sponsor.url}
                           target="_blank"
                           rel="noreferrer"
@@ -183,7 +189,7 @@ const Sponsors = ({ data }) => {
                           />
                         </a>
                       ) : (
-                        <div className="sponsors__logo-static">
+                        <div className="sponsors__logo-static sponsors__logo-tile">
                           <img
                             className="sponsors__logo"
                             src={sponsor.logo}


### PR DESCRIPTION
## Summary
- introduce reusable hero display, badge, and glass classes for improved hero typography and glassmorphism effects
- restyle the sponsors section with a new gradient backdrop, panel highlights, and adaptive logo treatments for dark and light themes
- ensure sponsor logos use responsive sizing, hover/focus glow states, and accessible focus management

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7daedb9a08323887384b6c38d16f5