### PR TITLE
feat: add sponsor slider and modal interactions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import Section from './components/Section.jsx';
 import Footer from './components/Footer.jsx';
@@ -33,6 +33,11 @@ import sponsorsConfig from './features/Sponsors/config.json';
 import './App.css';
 
 const App = () => {
+  const handleSponsorFormSubmit = useCallback(async (formData) => {
+    // Здесь мог бы быть вызов API или интеграция с сервисом отправки.
+    console.log('Sponsor form submitted', formData);
+  }, []);
+
   const sections = [
     {
       id: 'hero',
@@ -116,7 +121,12 @@ const App = () => {
     {
       id: 'sponsors',
       title: 'Партнёры и спонсоры',
-      component: <Sponsors data={sponsorsConfig} />,
+      component: (
+        <Sponsors
+          data={sponsorsConfig}
+          onSponsorFormSubmit={handleSponsorFormSubmit}
+        />
+      ),
       navLabel: 'Партнёры',
       variant: 'sponsors',
     },

--- a/src/components/SponsorModal/SponsorModal.css
+++ b/src/components/SponsorModal/SponsorModal.css
@@ -1,0 +1,307 @@
+.sponsor-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+}
+
+.sponsor-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(139, 123, 255, 0.25), transparent 65%),
+    radial-gradient(circle at 80% 30%, rgba(64, 232, 194, 0.22), transparent 65%),
+    rgba(5, 9, 24, 0.76);
+  backdrop-filter: blur(18px);
+}
+
+.sponsor-modal__overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  align-items: center;
+  justify-items: center;
+  padding: clamp(1.5rem, 5vw, 3rem);
+  overflow-y: auto;
+}
+
+.sponsor-modal__dialog {
+  position: relative;
+  width: min(620px, 100%);
+  display: grid;
+  gap: clamp(var(--space-3), 2vw, var(--space-4));
+  padding: clamp(1.8rem, 3.5vw, 2.6rem);
+  border-radius: clamp(1.6rem, 3vw, 2.2rem);
+  background:
+    radial-gradient(circle at 10% 0%, rgba(139, 123, 255, 0.22), transparent 55%),
+    radial-gradient(circle at 95% 12%, rgba(64, 232, 194, 0.16), transparent 60%),
+    rgba(12, 16, 32, 0.92);
+  border: 1px solid rgba(139, 123, 255, 0.28);
+  box-shadow: 0 40px 120px rgba(5, 9, 32, 0.65);
+  color: var(--sponsors-text-primary, #f8f9ff);
+}
+
+.sponsor-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.sponsor-modal__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+}
+
+.sponsor-modal__title {
+  margin: 0.4rem 0 0;
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+.sponsor-modal__subtitle {
+  margin: 0.75rem 0 0;
+  color: rgba(199, 210, 243, 0.82);
+  line-height: 1.6;
+}
+
+.sponsor-modal__close {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 999px;
+  border: 1px solid rgba(139, 123, 255, 0.3);
+  background: rgba(9, 12, 28, 0.65);
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform var(--transition-fast), background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.sponsor-modal__close:hover,
+.sponsor-modal__close:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(15, 20, 42, 0.85);
+  border-color: rgba(139, 123, 255, 0.5);
+}
+
+.sponsor-modal__close:focus-visible {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 3px;
+}
+
+.sponsor-modal__form {
+  display: grid;
+  gap: clamp(var(--space-3), 2vw, var(--space-4));
+}
+
+.sponsor-modal__field {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.sponsor-modal__label {
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(199, 210, 243, 0.9);
+}
+
+.sponsor-modal__input,
+.sponsor-modal__textarea {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(139, 123, 255, 0.24);
+  background: rgba(8, 12, 28, 0.75);
+  color: #f8f9ff;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast),
+    background var(--transition-fast);
+  resize: vertical;
+}
+
+.sponsor-modal__input::placeholder,
+.sponsor-modal__textarea::placeholder {
+  color: rgba(148, 163, 199, 0.6);
+}
+
+.sponsor-modal__input:focus-visible,
+.sponsor-modal__textarea:focus-visible {
+  outline: none;
+  border-color: rgba(139, 123, 255, 0.55);
+  background: rgba(12, 18, 40, 0.9);
+  box-shadow: 0 0 0 3px rgba(139, 123, 255, 0.25);
+}
+
+.sponsor-modal__textarea {
+  min-height: 140px;
+}
+
+.sponsor-modal__error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: rgba(255, 120, 120, 0.9);
+  font-size: 0.95rem;
+}
+
+.sponsor-modal__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+.sponsor-modal__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.9rem 1.9rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--gradient-primary);
+  color: #05060f;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast),
+    filter var(--transition-fast);
+}
+
+.sponsor-modal__submit:hover,
+.sponsor-modal__submit:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 60px rgba(139, 123, 255, 0.38);
+}
+
+.sponsor-modal__submit:disabled {
+  opacity: 0.7;
+  cursor: progress;
+  transform: none;
+  box-shadow: none;
+}
+
+.sponsor-modal__submit:focus-visible {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 3px;
+}
+
+.sponsor-modal__secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(199, 210, 243, 0.35);
+  background: transparent;
+  color: rgba(199, 210, 243, 0.88);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform var(--transition-fast), background var(--transition-fast),
+    border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.sponsor-modal__secondary:hover,
+.sponsor-modal__secondary:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(15, 20, 42, 0.78);
+  border-color: rgba(199, 210, 243, 0.65);
+}
+
+.sponsor-modal__secondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.sponsor-modal__secondary:focus-visible {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 3px;
+}
+
+@media (max-width: 640px) {
+  .sponsor-modal__dialog {
+    padding: clamp(1.6rem, 4vw, 2rem);
+  }
+
+  .sponsor-modal__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .sponsor-modal__close {
+    align-self: flex-end;
+    margin-top: 0.5rem;
+  }
+
+  .sponsor-modal__actions {
+    justify-content: stretch;
+  }
+
+  .sponsor-modal__submit,
+  .sponsor-modal__secondary {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+:root[data-theme='light'] .sponsor-modal__dialog,
+[data-theme='light'] .sponsor-modal__dialog {
+  background:
+    radial-gradient(circle at 12% 0%, rgba(139, 123, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 90% 18%, rgba(64, 232, 194, 0.18), transparent 60%),
+    rgba(247, 249, 255, 0.96);
+  border-color: rgba(139, 123, 255, 0.24);
+  color: #111534;
+}
+
+:root[data-theme='light'] .sponsor-modal__subtitle,
+[data-theme='light'] .sponsor-modal__subtitle {
+  color: rgba(60, 72, 114, 0.82);
+}
+
+:root[data-theme='light'] .sponsor-modal__input,
+:root[data-theme='light'] .sponsor-modal__textarea,
+[data-theme='light'] .sponsor-modal__input,
+[data-theme='light'] .sponsor-modal__textarea {
+  background: rgba(255, 255, 255, 0.82);
+  color: #111534;
+  border-color: rgba(139, 123, 255, 0.24);
+}
+
+:root[data-theme='light'] .sponsor-modal__input:focus-visible,
+:root[data-theme='light'] .sponsor-modal__textarea:focus-visible,
+[data-theme='light'] .sponsor-modal__input:focus-visible,
+[data-theme='light'] .sponsor-modal__textarea:focus-visible {
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 0 0 3px rgba(139, 123, 255, 0.2);
+}
+
+:root[data-theme='light'] .sponsor-modal__secondary,
+[data-theme='light'] .sponsor-modal__secondary {
+  border-color: rgba(60, 72, 114, 0.22);
+  color: rgba(60, 72, 114, 0.86);
+}
+
+:root[data-theme='light'] .sponsor-modal__secondary:hover,
+:root[data-theme='light'] .sponsor-modal__secondary:focus-visible,
+[data-theme='light'] .sponsor-modal__secondary:hover,
+[data-theme='light'] .sponsor-modal__secondary:focus-visible {
+  background: rgba(255, 255, 255, 0.8);
+  border-color: rgba(60, 72, 114, 0.42);
+}

--- a/src/components/SponsorModal/SponsorModal.jsx
+++ b/src/components/SponsorModal/SponsorModal.jsx
@@ -1,0 +1,285 @@
+import { useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import './SponsorModal.css';
+
+const INITIAL_FORM_STATE = {
+  name: '',
+  company: '',
+  email: '',
+  message: '',
+};
+
+const focusableSelectors =
+  'a[href], area[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const SponsorModal = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  isSubmitting,
+  errorMessage,
+}) => {
+  const dialogRef = useRef(null);
+  const nameInputRef = useRef(null);
+  const [formData, setFormData] = useState(INITIAL_FORM_STATE);
+
+  useEffect(() => {
+    if (isOpen) {
+      setFormData(INITIAL_FORM_STATE);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const dialogElement = dialogRef.current;
+
+    if (!dialogElement) {
+      return undefined;
+    }
+
+    const previouslyFocusedElement = document.activeElement;
+
+    const trapFocus = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== 'Tab') {
+        return;
+      }
+
+      const focusableElements = dialogElement.querySelectorAll(focusableSelectors);
+
+      if (!focusableElements.length) {
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (event.shiftKey) {
+        if (document.activeElement === firstElement) {
+          event.preventDefault();
+          lastElement.focus();
+        }
+      } else if (document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    const focusTimer = window.setTimeout(() => {
+      if (nameInputRef.current) {
+        nameInputRef.current.focus();
+      } else {
+        const fallbackTarget = dialogElement.querySelector(focusableSelectors);
+        fallbackTarget?.focus();
+      }
+    }, 0);
+
+    document.addEventListener('keydown', trapFocus);
+
+    return () => {
+      window.clearTimeout(focusTimer);
+      document.removeEventListener('keydown', trapFocus);
+      if (previouslyFocusedElement && previouslyFocusedElement.focus) {
+        previouslyFocusedElement.focus();
+      }
+    };
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event) => {
+      const dialogElement = dialogRef.current;
+
+      if (!dialogElement) {
+        return;
+      }
+
+      if (event.target instanceof Node && !dialogElement.contains(event.target)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    if (isSubmitting) {
+      return;
+    }
+
+    onSubmit({ ...formData });
+  };
+
+  return (
+    <div className="sponsor-modal" role="presentation">
+      <div className="sponsor-modal__backdrop" aria-hidden="true" />
+      <div className="sponsor-modal__overlay">
+        <div
+          className="sponsor-modal__dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="sponsor-modal-title"
+          ref={dialogRef}
+        >
+          <header className="sponsor-modal__header">
+            <div>
+              <p className="sponsor-modal__eyebrow">Партнёрская заявка</p>
+              <h2 id="sponsor-modal-title" className="sponsor-modal__title">
+                Присоединяйтесь к YarCyberSeason
+              </h2>
+              <p className="sponsor-modal__subtitle">
+                Заполните форму, и команда по работе с партнёрами свяжется с вами в ближайшее время.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="sponsor-modal__close"
+              onClick={onClose}
+              aria-label="Закрыть окно"
+            >
+              ×
+            </button>
+          </header>
+
+          <form className="sponsor-modal__form" onSubmit={handleSubmit}>
+            <div className="sponsor-modal__field">
+              <label className="sponsor-modal__label" htmlFor="sponsor-name">
+                Имя и фамилия
+              </label>
+              <input
+                ref={nameInputRef}
+                id="sponsor-name"
+                name="name"
+                type="text"
+                className="sponsor-modal__input"
+                placeholder="Например, Алексей Смирнов"
+                value={formData.name}
+                onChange={handleChange}
+                autoComplete="name"
+                required
+              />
+            </div>
+
+            <div className="sponsor-modal__field">
+              <label className="sponsor-modal__label" htmlFor="sponsor-company">
+                Компания
+              </label>
+              <input
+                id="sponsor-company"
+                name="company"
+                type="text"
+                className="sponsor-modal__input"
+                placeholder="Название компании"
+                value={formData.company}
+                onChange={handleChange}
+                autoComplete="organization"
+              />
+            </div>
+
+            <div className="sponsor-modal__field">
+              <label className="sponsor-modal__label" htmlFor="sponsor-email">
+                Рабочая почта
+              </label>
+              <input
+                id="sponsor-email"
+                name="email"
+                type="email"
+                className="sponsor-modal__input"
+                placeholder="partner@example.com"
+                value={formData.email}
+                onChange={handleChange}
+                autoComplete="email"
+                required
+              />
+            </div>
+
+            <div className="sponsor-modal__field">
+              <label className="sponsor-modal__label" htmlFor="sponsor-message">
+                Инициативы или вопросы
+              </label>
+              <textarea
+                id="sponsor-message"
+                name="message"
+                className="sponsor-modal__textarea"
+                placeholder="Расскажите, какие интеграции вы рассматриваете"
+                value={formData.message}
+                onChange={handleChange}
+                rows={4}
+              />
+            </div>
+
+            {errorMessage ? (
+              <p className="sponsor-modal__error" role="alert">
+                {errorMessage}
+              </p>
+            ) : null}
+
+            <div className="sponsor-modal__actions">
+              <button
+                type="submit"
+                className="sponsor-modal__submit"
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? 'Отправляем…' : 'Отправить заявку'}
+              </button>
+              <button
+                type="button"
+                className="sponsor-modal__secondary"
+                onClick={onClose}
+                disabled={isSubmitting}
+              >
+                Отменить
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+SponsorModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  isSubmitting: PropTypes.bool,
+  errorMessage: PropTypes.string,
+};
+
+SponsorModal.defaultProps = {
+  isSubmitting: false,
+  errorMessage: undefined,
+};
+
+export default SponsorModal;

--- a/src/features/Sponsors/Sponsors.css
+++ b/src/features/Sponsors/Sponsors.css
@@ -70,14 +70,22 @@
   line-height: 1.7;
 }
 
+.sponsors__cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
 .sponsors__cta {
   justify-self: flex-start;
   display: inline-flex;
   align-items: center;
   gap: 0.6rem;
-  padding: 0.8rem 1.75rem;
+  padding: 0.85rem 1.9rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid transparent;
+  background: transparent;
   color: var(--sponsors-text-primary);
   text-decoration: none;
   letter-spacing: 0.16em;
@@ -86,13 +94,39 @@
   box-shadow: 0 18px 48px rgba(9, 14, 32, 0.4);
   backdrop-filter: blur(14px);
   transition: transform var(--transition-fast), background var(--transition-fast),
-    box-shadow var(--transition-fast);
+    box-shadow var(--transition-fast), border-color var(--transition-fast),
+    color var(--transition-fast);
+  cursor: pointer;
 }
 
-.sponsors__cta:hover,
 .sponsors__cta:focus-visible {
+  outline: 2px solid var(--color-secondary);
+  outline-offset: 3px;
+}
+
+.sponsors__cta--primary {
+  background: var(--gradient-primary);
+  color: #05060f;
+  box-shadow: 0 22px 56px rgba(139, 123, 255, 0.34);
+}
+
+.sponsors__cta--primary:hover,
+.sponsors__cta--primary:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 28px 72px rgba(139, 123, 255, 0.4);
+}
+
+.sponsors__cta--ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--sponsors-text-primary);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.sponsors__cta--ghost:hover,
+.sponsors__cta--ghost:focus-visible {
   transform: translateY(-3px);
   background: rgba(255, 255, 255, 0.18);
+  border-color: rgba(255, 255, 255, 0.24);
   box-shadow: 0 26px 64px rgba(9, 14, 32, 0.55);
 }
 
@@ -403,6 +437,83 @@
   align-items: stretch;
 }
 
+.sponsors__logos--slider {
+  position: relative;
+  display: flex;
+  gap: var(--space-3);
+  overflow-x: auto;
+  overflow-y: visible;
+  padding-block: var(--space-2);
+  padding-inline: clamp(var(--space-2), 3vw, var(--space-4));
+  margin-inline: calc(-1 * clamp(var(--space-2), 3vw, var(--space-4)));
+  scroll-snap-type: x mandatory;
+  scroll-padding-inline: clamp(var(--space-2), 3vw, var(--space-4));
+  scrollbar-width: thin;
+  scrollbar-color: rgba(139, 123, 255, 0.45) transparent;
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
+}
+
+.sponsors__logos--slider::before,
+.sponsors__logos--slider::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: clamp(1.25rem, 6vw, 3rem);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.sponsors__logos--slider::before {
+  left: 0;
+  background: linear-gradient(90deg, rgba(9, 14, 32, 0.8), transparent);
+}
+
+.sponsors__logos--slider::after {
+  right: 0;
+  background: linear-gradient(270deg, rgba(9, 14, 32, 0.8), transparent);
+}
+
+.sponsors__logos--slider::-webkit-scrollbar {
+  height: 8px;
+}
+
+.sponsors__logos--slider::-webkit-scrollbar-track {
+  background: rgba(8, 12, 28, 0.35);
+  border-radius: 999px;
+}
+
+.sponsors__logos--slider::-webkit-scrollbar-thumb {
+  background: rgba(139, 123, 255, 0.55);
+  border-radius: 999px;
+}
+
+.sponsors__logos--slider .sponsors__logo-item {
+  flex: 0 0 clamp(200px, 68vw, 260px);
+  scroll-snap-align: center;
+}
+
+.sponsors__logos--slider .sponsors__logo-tile {
+  min-height: 100%;
+}
+
+@supports not (scroll-snap-type: x mandatory) {
+  .sponsors__logos--slider {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    margin-inline: 0;
+    padding-inline: 0;
+    overflow: visible;
+  }
+}
+
+@media (min-width: 768px) {
+  .sponsors__logos--slider .sponsors__logo-item {
+    flex: 0 0 clamp(220px, 32vw, 280px);
+  }
+}
+
 @media (min-width: 1024px) {
   .sponsors__featured {
     grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
@@ -434,6 +545,33 @@
     radial-gradient(circle at 20% 20%, rgba(160, 166, 255, 0.32), transparent 60%),
     radial-gradient(circle at 80% 0%, rgba(142, 225, 255, 0.2), transparent 60%),
     linear-gradient(165deg, rgba(242, 244, 255, 0.95), rgba(225, 232, 255, 0.92));
+}
+
+:root[data-theme='light'] .sponsors__logos--slider::before,
+:root[data-theme='light'] .sponsors__logos--slider::after,
+[data-theme='light'] .sponsors__logos--slider::before,
+[data-theme='light'] .sponsors__logos--slider::after {
+  background: linear-gradient(
+    90deg,
+    rgba(245, 247, 255, 0.92),
+    rgba(245, 247, 255, 0.06)
+  );
+}
+
+:root[data-theme='light'] .sponsors__logos--slider::after {
+  background: linear-gradient(
+    270deg,
+    rgba(245, 247, 255, 0.92),
+    rgba(245, 247, 255, 0.06)
+  );
+}
+
+[data-theme='light'] .sponsors__logos--slider::after {
+  background: linear-gradient(
+    270deg,
+    rgba(245, 247, 255, 0.92),
+    rgba(245, 247, 255, 0.06)
+  );
 }
 
 :root[data-theme='light'] .sponsors__description,
@@ -492,5 +630,22 @@
   :root:not([data-theme='dark']) .sponsors__logo,
   :root:not([data-theme='dark']) .sponsors__featured-logo-image {
     filter: brightness(1.05) contrast(1.12) saturate(1.05);
+  }
+
+  :root:not([data-theme='dark']) .sponsors__logos--slider::before,
+  :root:not([data-theme='dark']) .sponsors__logos--slider::after {
+    background: linear-gradient(
+      90deg,
+      rgba(245, 247, 255, 0.92),
+      rgba(245, 247, 255, 0.08)
+    );
+  }
+
+  :root:not([data-theme='dark']) .sponsors__logos--slider::after {
+    background: linear-gradient(
+      270deg,
+      rgba(245, 247, 255, 0.92),
+      rgba(245, 247, 255, 0.08)
+    );
   }
 }

--- a/src/features/Sponsors/Sponsors.jsx
+++ b/src/features/Sponsors/Sponsors.jsx
@@ -1,23 +1,349 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import SponsorModal from '../../components/SponsorModal/SponsorModal.jsx';
 import './Sponsors.css';
 
-const Sponsors = ({ data }) => {
+const SLIDER_SPONSOR_THRESHOLD = 6;
+
+const useAutoScroll = (isEnabled) => {
+  const listRef = useRef(null);
+
+  useEffect(() => {
+    if (!isEnabled || typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const listElement = listRef.current;
+
+    if (!listElement) {
+      return undefined;
+    }
+
+    const prefersReducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    );
+    const desktopMedia = window.matchMedia(
+      '(pointer: fine) and (min-width: 1024px)',
+    );
+
+    if (prefersReducedMotion.matches || !desktopMedia.matches) {
+      return undefined;
+    }
+
+    let animationFrame;
+    let isHovering = false;
+    let lastTime;
+    let direction = 1;
+    let isActive = false;
+    let isInView = false;
+
+    const step = (timestamp) => {
+      if (!isActive || !listRef.current) {
+        return;
+      }
+
+      if (isHovering) {
+        lastTime = timestamp;
+        animationFrame = window.requestAnimationFrame(step);
+        return;
+      }
+
+      if (typeof lastTime !== 'number') {
+        lastTime = timestamp;
+        animationFrame = window.requestAnimationFrame(step);
+        return;
+      }
+
+      const delta = timestamp - lastTime;
+      lastTime = timestamp;
+
+      const element = listRef.current;
+      const maxScroll = element.scrollWidth - element.clientWidth;
+
+      if (maxScroll <= 0) {
+        isActive = false;
+        return;
+      }
+
+      const speed = 0.12;
+      element.scrollLeft += direction * speed * delta;
+
+      if (element.scrollLeft <= 0) {
+        element.scrollLeft = 0;
+        direction = 1;
+      } else if (element.scrollLeft >= maxScroll) {
+        element.scrollLeft = maxScroll;
+        direction = -1;
+      }
+
+      animationFrame = window.requestAnimationFrame(step);
+    };
+
+    const start = () => {
+      if (isActive) {
+        return;
+      }
+      isActive = true;
+      lastTime = undefined;
+      animationFrame = window.requestAnimationFrame(step);
+    };
+
+    const stop = () => {
+      isActive = false;
+      if (animationFrame) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+    };
+
+    const observer = new window.IntersectionObserver(
+      ([entry]) => {
+        isInView = entry.isIntersecting;
+        if (isInView && desktopMedia.matches && !prefersReducedMotion.matches) {
+          start();
+        } else {
+          stop();
+        }
+      },
+      { threshold: 0.25 },
+    );
+
+    observer.observe(listElement);
+
+    const handleMouseEnter = () => {
+      isHovering = true;
+    };
+
+    const handleMouseLeave = () => {
+      isHovering = false;
+    };
+
+    listElement.addEventListener('mouseenter', handleMouseEnter);
+    listElement.addEventListener('mouseleave', handleMouseLeave);
+
+    const handleDesktopChange = (event) => {
+      if (!event.matches) {
+        stop();
+      } else if (isInView && !prefersReducedMotion.matches) {
+        start();
+      }
+    };
+
+    const handleMotionChange = (event) => {
+      if (event.matches) {
+        stop();
+      } else if (isInView && desktopMedia.matches) {
+        start();
+      }
+    };
+
+    desktopMedia.addEventListener('change', handleDesktopChange);
+    prefersReducedMotion.addEventListener('change', handleMotionChange);
+
+    return () => {
+      stop();
+      observer.disconnect();
+      listElement.removeEventListener('mouseenter', handleMouseEnter);
+      listElement.removeEventListener('mouseleave', handleMouseLeave);
+      desktopMedia.removeEventListener('change', handleDesktopChange);
+      prefersReducedMotion.removeEventListener('change', handleMotionChange);
+    };
+  }, [isEnabled]);
+
+  return listRef;
+};
+
+const SponsorsTier = ({ tier, enableSlider, enableAutoScroll }) => {
+  const sliderRef = useAutoScroll(enableSlider && enableAutoScroll);
+
+  const sponsors = Array.isArray(tier?.sponsors) ? tier.sponsors : [];
+
+  return (
+    <section
+      className="sponsors__tier sponsors__panel"
+      aria-labelledby={`${tier.id}-heading`}
+    >
+      <div className="sponsors__tier-header">
+        <h3 id={`${tier.id}-heading`} className="sponsors__tier-title">
+          {tier.label}
+        </h3>
+        {tier.description ? (
+          <p className="sponsors__tier-description">{tier.description}</p>
+        ) : null}
+        {Array.isArray(tier.highlights) && tier.highlights.length ? (
+          <ul className="sponsors__tier-highlights">
+            {tier.highlights.map((highlight, index) => (
+              <li key={`${tier.id}-highlight-${index}`}>{highlight}</li>
+            ))}
+          </ul>
+        ) : null}
+        {Array.isArray(tier.stats) && tier.stats.length ? (
+          <dl className="sponsors__tier-stats">
+            {tier.stats.map((stat, index) => (
+              <div key={`${tier.id}-stat-${index}`} className="sponsors__tier-stat">
+                {stat.value ? (
+                  <dt className="sponsors__tier-stat-value">{stat.value}</dt>
+                ) : null}
+                {stat.label ? (
+                  <dd className="sponsors__tier-stat-label">{stat.label}</dd>
+                ) : null}
+              </div>
+            ))}
+          </dl>
+        ) : null}
+      </div>
+      <ul
+        ref={enableSlider ? sliderRef : null}
+        className={`sponsors__logos${enableSlider ? ' sponsors__logos--slider' : ''}`}
+      >
+        {sponsors.map((sponsor) => {
+          const hasLink = Boolean(sponsor?.url);
+
+          return (
+            <li
+              key={sponsor.name}
+              className="sponsors__logo-item sponsors__logo-spot"
+            >
+              {hasLink ? (
+                <a
+                  className="sponsors__logo-link sponsors__logo-tile"
+                  href={sponsor.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={`Перейти на сайт ${sponsor.name}`}
+                >
+                  <img
+                    className="sponsors__logo"
+                    src={sponsor.logo}
+                    alt={sponsor.alt || sponsor.name}
+                    loading="lazy"
+                  />
+                </a>
+              ) : (
+                <div className="sponsors__logo-static sponsors__logo-tile">
+                  <img
+                    className="sponsors__logo"
+                    src={sponsor.logo}
+                    alt={sponsor.alt || sponsor.name}
+                    loading="lazy"
+                  />
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+};
+
+SponsorsTier.propTypes = {
+  tier: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    highlights: PropTypes.arrayOf(PropTypes.string),
+    stats: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string,
+        value: PropTypes.string,
+      }),
+    ),
+    sponsors: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        logo: PropTypes.string.isRequired,
+        url: PropTypes.string,
+        alt: PropTypes.string,
+      }),
+    ),
+  }).isRequired,
+  enableSlider: PropTypes.bool,
+  enableAutoScroll: PropTypes.bool,
+};
+
+SponsorsTier.defaultProps = {
+  enableSlider: false,
+  enableAutoScroll: false,
+};
+
+const Sponsors = ({ data, onSponsorFormSubmit }) => {
   const intro = data?.intro ?? {};
-  const tiers = Array.isArray(data?.tiers) ? data.tiers : [];
+  const tiers = useMemo(
+    () => (Array.isArray(data?.tiers) ? data.tiers : []),
+    [data],
+  );
 
   const featuredTier = tiers.find((tier) => tier?.featured);
-  const regularTiers = tiers.filter((tier) => !tier?.featured);
 
   const featuredSponsors = Array.isArray(featuredTier?.sponsors)
     ? featuredTier.sponsors
     : [];
-  const regularTiersWithSponsors = regularTiers.filter((tier) =>
-    Array.isArray(tier?.sponsors) && tier.sponsors.length > 0,
+
+  const regularTiersWithMeta = useMemo(
+    () =>
+      tiers
+        .filter(
+          (tier) =>
+            !tier?.featured && Array.isArray(tier?.sponsors) && tier.sponsors.length > 0,
+        )
+        .map((tier) => {
+          const sponsors = tier.sponsors;
+          const preferSlider = tier.layout === 'slider';
+          const enableSlider = preferSlider || sponsors.length > SLIDER_SPONSOR_THRESHOLD;
+          const enableAutoScroll = enableSlider && (tier.autoScroll ?? true);
+
+          return {
+            ...tier,
+            sponsors,
+            enableSlider,
+            enableAutoScroll,
+          };
+        }),
+    [tiers],
   );
 
   const heroCta = featuredTier?.cta;
   const heroCtaHref = typeof heroCta?.href === 'string' ? heroCta.href : '';
   const heroCtaIsExternal = /^https?:/i.test(heroCtaHref);
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submissionError, setSubmissionError] = useState(null);
+
+  const openModal = useCallback(() => {
+    setIsModalOpen(true);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setIsModalOpen(false);
+    setSubmissionError(null);
+    setIsSubmitting(false);
+  }, []);
+
+  const handleModalSubmit = useCallback(
+    async (formData) => {
+      setSubmissionError(null);
+
+      if (typeof onSponsorFormSubmit !== 'function') {
+        setIsModalOpen(false);
+        return;
+      }
+
+      try {
+        setIsSubmitting(true);
+        await Promise.resolve(onSponsorFormSubmit(formData));
+        setIsModalOpen(false);
+      } catch (error) {
+        console.error('Не удалось отправить форму спонсора', error);
+        setSubmissionError('Не удалось отправить форму. Попробуйте ещё раз.');
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [onSponsorFormSubmit],
+  );
+
+  const hasDownloadCta = Boolean(intro?.download?.href && intro?.download?.label);
 
   return (
     <div className="sponsors">
@@ -28,16 +354,25 @@ const Sponsors = ({ data }) => {
         {intro?.description ? (
           <p className="sponsors__description">{intro.description}</p>
         ) : null}
-        {intro?.download?.href && intro?.download?.label ? (
-          <a
-            className="sponsors__cta"
-            href={intro.download.href}
-            target="_blank"
-            rel="noreferrer"
+        <div className="sponsors__cta-group">
+          <button
+            type="button"
+            className="sponsors__cta sponsors__cta--primary"
+            onClick={openModal}
           >
-            {intro.download.label}
-          </a>
-        ) : null}
+            Стать спонсором
+          </button>
+          {hasDownloadCta ? (
+            <a
+              className="sponsors__cta sponsors__cta--ghost"
+              href={intro.download.href}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {intro.download.label}
+            </a>
+          ) : null}
+        </div>
       </div>
 
       {featuredTier ? (
@@ -127,85 +462,26 @@ const Sponsors = ({ data }) => {
         </section>
       ) : null}
 
-      {regularTiersWithSponsors.length ? (
+      {regularTiersWithMeta.length ? (
         <div className="sponsors__tiers">
-          {regularTiersWithSponsors.map((tier) => (
-            <section
+          {regularTiersWithMeta.map((tier) => (
+            <SponsorsTier
               key={tier.id}
-              className="sponsors__tier sponsors__panel"
-              aria-labelledby={`${tier.id}-heading`}
-            >
-              <div className="sponsors__tier-header">
-                <h3 id={`${tier.id}-heading`} className="sponsors__tier-title">
-                  {tier.label}
-                </h3>
-                {tier.description ? (
-                  <p className="sponsors__tier-description">{tier.description}</p>
-                ) : null}
-                {Array.isArray(tier.highlights) && tier.highlights.length ? (
-                  <ul className="sponsors__tier-highlights">
-                    {tier.highlights.map((highlight, index) => (
-                      <li key={`${tier.id}-highlight-${index}`}>{highlight}</li>
-                    ))}
-                  </ul>
-                ) : null}
-                {Array.isArray(tier.stats) && tier.stats.length ? (
-                  <dl className="sponsors__tier-stats">
-                    {tier.stats.map((stat, index) => (
-                      <div key={`${tier.id}-stat-${index}`} className="sponsors__tier-stat">
-                        {stat.value ? (
-                          <dt className="sponsors__tier-stat-value">{stat.value}</dt>
-                        ) : null}
-                        {stat.label ? (
-                          <dd className="sponsors__tier-stat-label">{stat.label}</dd>
-                        ) : null}
-                      </div>
-                    ))}
-                  </dl>
-                ) : null}
-              </div>
-              <ul className="sponsors__logos">
-                {(Array.isArray(tier.sponsors) ? tier.sponsors : []).map((sponsor) => {
-                  const hasLink = Boolean(sponsor?.url);
-
-                  return (
-                    <li
-                      key={sponsor.name}
-                      className="sponsors__logo-item sponsors__logo-spot"
-                    >
-                      {hasLink ? (
-                        <a
-                          className="sponsors__logo-link sponsors__logo-tile"
-                          href={sponsor.url}
-                          target="_blank"
-                          rel="noreferrer"
-                          aria-label={`Перейти на сайт ${sponsor.name}`}
-                        >
-                          <img
-                            className="sponsors__logo"
-                            src={sponsor.logo}
-                            alt={sponsor.alt || sponsor.name}
-                            loading="lazy"
-                          />
-                        </a>
-                      ) : (
-                        <div className="sponsors__logo-static sponsors__logo-tile">
-                          <img
-                            className="sponsors__logo"
-                            src={sponsor.logo}
-                            alt={sponsor.alt || sponsor.name}
-                            loading="lazy"
-                          />
-                        </div>
-                      )}
-                    </li>
-                  );
-                })}
-              </ul>
-            </section>
+              tier={tier}
+              enableSlider={tier.enableSlider}
+              enableAutoScroll={tier.enableAutoScroll}
+            />
           ))}
         </div>
       ) : null}
+
+      <SponsorModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        onSubmit={handleModalSubmit}
+        isSubmitting={isSubmitting}
+        errorMessage={submissionError}
+      />
     </div>
   );
 };
@@ -243,6 +519,8 @@ Sponsors.propTypes = {
         label: PropTypes.string.isRequired,
         description: PropTypes.string,
         featured: PropTypes.bool,
+        layout: PropTypes.oneOf(['slider', 'grid']),
+        autoScroll: PropTypes.bool,
         highlights: PropTypes.arrayOf(PropTypes.string),
         stats: PropTypes.arrayOf(statShape),
         cta: ctaShape,
@@ -250,6 +528,11 @@ Sponsors.propTypes = {
       }),
     ),
   }).isRequired,
+  onSponsorFormSubmit: PropTypes.func,
+};
+
+Sponsors.defaultProps = {
+  onSponsorFormSubmit: undefined,
 };
 
 export default Sponsors;


### PR DESCRIPTION
## Summary
- add a scroll-snap slider with auto scroll for secondary sponsor tiers and keep a grid fallback
- introduce a sponsor enquiry modal with a new CTA button and wire it to the parent submit handler
- refresh horizontal scroll and modal styling for desktop and mobile themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7de2320008323ad2fe105871e410f