### PR TITLE
fix: shrink top navigation footprint

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -13,17 +13,18 @@ main.app {
   max-width: var(--max-width);
   margin-inline: auto;
   position: sticky;
-  top: clamp(0.5rem, 2vw, 1.5rem);
+  top: clamp(0.5rem, 2vw, 1.25rem);
   z-index: 50;
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--space-4);
-  padding: var(--space-4) clamp(var(--space-4), 3vw, var(--space-6));
-  border-radius: var(--radius-xl);
+  gap: clamp(var(--space-3), 2vw, var(--space-4));
+  padding: clamp(var(--space-3), 2.5vw, var(--space-4))
+    clamp(var(--space-3), 2.5vw, var(--space-5));
+  border-radius: var(--radius-lg);
   background: linear-gradient(140deg, rgba(18, 25, 48, 0.95), rgba(24, 36, 69, 0.88));
   border: 1px solid var(--color-border);
-  box-shadow: 0 18px 48px rgba(5, 9, 24, 0.65);
+  box-shadow: 0 12px 38px rgba(5, 9, 24, 0.55);
   backdrop-filter: blur(16px);
 }
 
@@ -38,20 +39,20 @@ main.app {
 .app__logo-mark {
   display: inline-grid;
   place-items: center;
-  width: 64px;
-  height: 64px;
+  width: 52px;
+  height: 52px;
   border-radius: var(--radius-lg);
   background: var(--gradient-primary);
   color: #05060f;
   font-weight: 800;
-  letter-spacing: 0.12em;
-  font-size: 1.7rem;
-  box-shadow: inset 0 0 24px rgba(255, 255, 255, 0.2), 0 12px 30px rgba(139, 123, 255, 0.45);
+  letter-spacing: 0.1em;
+  font-size: 1.4rem;
+  box-shadow: inset 0 0 20px rgba(255, 255, 255, 0.18), 0 10px 26px rgba(139, 123, 255, 0.42);
 }
 
 .app__logo-text {
-  font-size: 0.95rem;
-  letter-spacing: 0.18em;
+  font-size: 0.9rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--color-text-secondary);
 }
@@ -67,7 +68,7 @@ main.app {
   list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: var(--space-2);
+  gap: clamp(var(--space-1), 1.2vw, var(--space-2));
 }
 
 .app__nav-link {
@@ -75,12 +76,14 @@ main.app {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.55rem 1.05rem;
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
   text-decoration: none;
   color: var(--color-text-secondary);
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid transparent;
+  font-size: 0.95rem;
+  line-height: 1.15;
   transition: background-color var(--transition-normal), color var(--transition-fast), border-color var(--transition-fast),
     transform var(--transition-fast);
 }
@@ -111,13 +114,13 @@ main.app {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.85rem 1.65rem;
+  padding: 0.75rem 1.4rem;
   border-radius: var(--radius-md);
   background: var(--gradient-primary);
   color: #05060f;
   font-weight: 700;
   text-decoration: none;
-  box-shadow: 0 20px 40px rgba(139, 123, 255, 0.4);
+  box-shadow: 0 16px 32px rgba(139, 123, 255, 0.38);
   transition: transform var(--transition-normal), box-shadow var(--transition-normal);
 }
 
@@ -211,7 +214,7 @@ main.app {
   .app__header {
     top: 0;
     border-radius: var(--radius-lg);
-    padding: var(--space-3);
+    padding: var(--space-3) var(--space-3) var(--space-2);
     grid-template-columns: auto auto;
     grid-template-areas:
       'logo toggle'
@@ -219,7 +222,7 @@ main.app {
       'cta cta';
     align-items: center;
     justify-items: stretch;
-    row-gap: var(--space-3);
+    row-gap: var(--space-2);
   }
 
   .app__cta {
@@ -243,7 +246,7 @@ main.app {
     display: none;
     grid-area: nav;
     width: 100%;
-    padding: var(--space-3);
+    padding: var(--space-2);
     background: linear-gradient(140deg, rgba(18, 25, 48, 0.95), rgba(24, 36, 69, 0.92));
     border-radius: var(--radius-md);
     border: 1px solid rgba(139, 123, 255, 0.25);
@@ -256,12 +259,13 @@ main.app {
 
   .app__nav-list {
     flex-direction: column;
-    gap: var(--space-2);
+    gap: var(--space-1);
   }
 
   .app__nav-link {
     width: 100%;
     justify-content: flex-start;
+    padding: 0.6rem 0.75rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- tighten header spacing to reduce the height of the sticky navigation bar
- scale down the logo mark, navigation pills, and call-to-action button for a lighter look
- tweak mobile navigation padding and gaps so the expanded menu takes up less room on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8827146508323a3ff5a745434b23b