### PR TITLE
Refactor hero layout to highlight key facts

### DIFF
--- a/src/features/Hero/Hero.css
+++ b/src/features/Hero/Hero.css
@@ -172,64 +172,12 @@
   opacity: 0.72;
 }
 
-.hero__glass--strong {
-  background: linear-gradient(140deg, rgba(12, 18, 36, 0.82), rgba(26, 30, 58, 0.85));
-  border-color: rgba(139, 123, 255, 0.35);
-}
-
-.hero__glass--soft {
-  background: linear-gradient(155deg, rgba(15, 22, 42, 0.68), rgba(22, 32, 58, 0.72));
-}
-
 .hero__topbar {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  gap: var(--space-3);
+  gap: clamp(var(--space-2), 2vw, var(--space-3));
   align-items: center;
-}
-
-.hero__topnav {
-  display: flex;
-  align-items: center;
-}
-
-.hero__topnav-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-}
-
-.hero__topnav-item {
-  display: inline-flex;
-}
-
-.hero__topnav-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.4rem 0.9rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  color: var(--color-text-secondary);
-  text-decoration: none;
-  font-size: 0.8rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  transition: background var(--transition-fast), color var(--transition-fast), border var(--transition-fast),
-    transform var(--transition-fast);
-}
-
-.hero__topnav-link:hover,
-.hero__topnav-link:focus-visible {
-  background: var(--gradient-primary);
-  color: #05060f;
-  border-color: transparent;
-  transform: translateY(-1px);
 }
 
 .hero__brand {
@@ -251,23 +199,21 @@
   text-transform: uppercase;
 }
 
-.hero__branding {
+.hero__brand-text {
   display: grid;
-  gap: 0.25rem;
+  gap: 0.15rem;
 }
 
-.hero__branding-title {
-  margin: 0;
-  font-size: 0.8rem;
+.hero__brand-tagline {
+  font-size: 0.75rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
 
-.hero__branding-subtitle {
-  margin: 0;
+.hero__brand-label {
   font-weight: 600;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--color-text-secondary);
 }
@@ -292,12 +238,19 @@
   letter-spacing: 0.32em;
 }
 
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  align-items: center;
+  margin-top: clamp(var(--space-2), 2vw, var(--space-3));
+}
+
 .hero__primary-cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  margin-top: var(--space-3);
   padding: 0.75rem clamp(1.5rem, 4vw, 2.4rem);
   border-radius: 999px;
   background: var(--gradient-primary);
@@ -316,10 +269,41 @@
   box-shadow: 0 26px 55px rgba(139, 123, 255, 0.45);
 }
 
+.hero__quicklinks {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.hero__quicklink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  font-size: 0.8rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  transition: background var(--transition-fast), color var(--transition-fast), border var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.hero__quicklink:hover,
+.hero__quicklink:focus-visible {
+  background: var(--gradient-primary);
+  color: #05060f;
+  border-color: transparent;
+  transform: translateY(-1px);
+}
+
 .hero__keyfacts {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: clamp(var(--space-3), 3vw, var(--space-4));
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(var(--space-3), 3.5vw, var(--space-5));
 }
 
 .hero__keyfact {
@@ -391,145 +375,6 @@
   background: var(--gradient-primary);
   color: #05060f;
   transform: translateY(-2px);
-}
-
-.hero__matchup {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, auto));
-  align-items: center;
-  gap: var(--space-4);
-  padding: var(--space-3);
-  border-radius: var(--radius-lg);
-}
-
-.hero__match-side {
-  display: grid;
-  gap: var(--space-1);
-}
-
-.hero__match-code {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.35em;
-  color: var(--color-secondary);
-}
-
-.hero__match-name {
-  font-size: 1.25rem;
-  font-weight: 700;
-}
-
-.hero__match-note {
-  font-size: 0.85rem;
-  color: var(--color-text-muted);
-}
-
-.hero__match-versus {
-  font-weight: 700;
-  letter-spacing: 0.45em;
-  color: var(--color-tertiary);
-}
-
-.hero__tabs {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  padding: var(--space-2);
-  border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.hero__tab {
-  position: relative;
-  padding: 0.45rem 1.2rem;
-  border-radius: 999px;
-  text-decoration: none;
-  color: var(--color-text-secondary);
-  transition: background var(--transition-normal), color var(--transition-fast);
-}
-
-.hero__tab::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(130deg, rgba(139, 123, 255, 0.6), rgba(64, 232, 194, 0.6));
-  opacity: 0;
-  transition: opacity var(--transition-normal);
-  z-index: -1;
-}
-
-.hero__tab:hover,
-.hero__tab:focus-visible {
-  color: var(--color-bg);
-}
-
-.hero__tab:hover::before,
-.hero__tab:focus-visible::before {
-  opacity: 1;
-}
-
-.hero__qualifiers {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: var(--space-4);
-}
-
-.hero__qualifier {
-  position: relative;
-  padding: var(--space-4);
-  border-radius: var(--radius-lg);
-  overflow: hidden;
-}
-
-.hero__qualifier::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at top right, rgba(139, 123, 255, 0.35), transparent 65%);
-  opacity: 0;
-  transition: opacity var(--transition-normal);
-  pointer-events: none;
-}
-
-.hero__qualifier:hover::before,
-.hero__qualifier:focus-within::before {
-  opacity: 1;
-}
-
-.hero__qualifier-tag {
-  letter-spacing: 0.25em;
-}
-
-.hero__qualifier-title {
-  margin: var(--space-2) 0 var(--space-1);
-  font-size: 1.2rem;
-}
-
-.hero__qualifier-description {
-  margin: 0;
-  color: var(--color-text-muted);
-}
-
-.hero__qualifier-cta {
-  display: inline-flex;
-  margin-top: var(--space-3);
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.55rem 1.2rem;
-  border-radius: 999px;
-  background: rgba(139, 123, 255, 0.15);
-  color: var(--color-text-primary);
-  text-decoration: none;
-  transition: transform var(--transition-fast), background var(--transition-fast);
-}
-
-.hero__qualifier-cta:hover,
-.hero__qualifier-cta:focus-visible {
-  transform: translateY(-2px);
-  background: var(--gradient-primary);
-  color: #05060f;
 }
 
 .hero__footer {
@@ -606,23 +451,6 @@
   text-transform: uppercase;
 }
 
-.hero__logos {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  align-items: center;
-}
-
-.hero__logo-chip {
-  padding: 0.35rem 0.9rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  color: var(--color-text-primary);
-  font-size: 0.85rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
 @keyframes countdownPulse {
   0%,
   100% {
@@ -646,17 +474,16 @@
     gap: var(--space-5);
   }
 
-  .hero__matchup {
-    grid-template-columns: 1fr;
-    text-align: center;
-  }
-
   .hero__countdown-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .hero__keyfacts {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero__actions {
+    gap: var(--space-2);
   }
 
   .hero__primary-cta {
@@ -681,20 +508,6 @@
     gap: var(--space-2);
   }
 
-  .hero__topnav {
-    width: 100%;
-  }
-
-  .hero__topnav-list {
-    width: 100%;
-    justify-content: flex-start;
-  }
-
-  .hero__tabs {
-    width: 100%;
-    justify-content: center;
-  }
-
   .hero__primary-cta {
     width: 100%;
   }
@@ -703,13 +516,19 @@
     grid-template-columns: 1fr;
   }
 
-  .hero__qualifiers {
-    grid-template-columns: 1fr;
-  }
-
   .hero__countdown {
     width: 100%;
     min-width: 100%;
+  }
+
+  .hero__quicklinks {
+    width: 100%;
+  }
+
+  .hero__quicklink {
+    justify-content: center;
+    flex: 1 1 45%;
+    min-width: calc(50% - var(--space-2));
   }
 }
 

--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -56,12 +56,8 @@ const Hero = ({ data }) => {
     title,
     subtitle,
     background,
-    match,
-    tabs,
-    qualifiers,
     prize,
     timer,
-    logos,
     media,
     keyFacts,
     primaryCta,
@@ -176,19 +172,6 @@ const Hero = ({ data }) => {
               {branding?.label ? <span className="hero__brand-label">{branding.label}</span> : null}
             </div>
           </div>
-          {Array.isArray(branding?.links) && branding.links.length > 0 ? (
-            <nav className="hero__topnav" aria-label="Навигация по турниру">
-              <ul className="hero__topnav-list">
-                {branding.links.map((link) => (
-                  <li key={`${link.href || link.label}`} className="hero__topnav-item">
-                    <a className="hero__topnav-link" href={link.href}>
-                      {link.label}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-          ) : null}
         </header>
 
         <div className="hero__centerpiece">
@@ -203,49 +186,26 @@ const Hero = ({ data }) => {
           <h1 className="hero__title hero__display">{title}</h1>
           <p className="hero__subtitle hero__display-subtitle">{subtitle}</p>
 
-          {primaryCta ? (
-            <a
-              className="hero__primary-cta"
-              href={primaryCta.href}
-              aria-label={primaryCta.ariaLabel || primaryCta.label}
-            >
-              {primaryCta.label}
-            </a>
-          ) : null}
-
-          {match ? (
-            <div
-              className="hero__matchup hero__glass hero__glass--strong"
-              role="group"
-              aria-label="Противостояние игр"
-            >
-              {match.left ? (
-                <div className="hero__match-side hero__match-side--left">
-                  <span className="hero__match-code">{match.left.code}</span>
-                  <span className="hero__match-name">{match.left.name}</span>
-                  {match.left.note ? <span className="hero__match-note">{match.left.note}</span> : null}
-                </div>
-              ) : null}
-              <span className="hero__match-versus" aria-hidden="true">
-                VS
-              </span>
-              {match.right ? (
-                <div className="hero__match-side hero__match-side--right">
-                  <span className="hero__match-code">{match.right.code}</span>
-                  <span className="hero__match-name">{match.right.name}</span>
-                  {match.right.note ? <span className="hero__match-note">{match.right.note}</span> : null}
-                </div>
-              ) : null}
-            </div>
-          ) : null}
-
-          {Array.isArray(tabs) && tabs.length > 0 ? (
-            <div className="hero__tabs" role="tablist" aria-label="Игровые дисциплины">
-              {tabs.map((tab) => (
-                <a key={`${tab.href || tab.label}`} className="hero__tab" href={tab.href} role="tab">
-                  {tab.label}
+          {primaryCta || (Array.isArray(branding?.links) && branding.links.length > 0) ? (
+            <div className="hero__actions">
+              {primaryCta ? (
+                <a
+                  className="hero__primary-cta"
+                  href={primaryCta.href}
+                  aria-label={primaryCta.ariaLabel || primaryCta.label}
+                >
+                  {primaryCta.label}
                 </a>
-              ))}
+              ) : null}
+              {Array.isArray(branding?.links) && branding.links.length > 0 ? (
+                <nav className="hero__quicklinks" aria-label="Полезные ссылки сезона">
+                  {branding.links.map((link) => (
+                    <a key={`${link.href || link.label}`} className="hero__quicklink" href={link.href}>
+                      {link.label}
+                    </a>
+                  ))}
+                </nav>
+              ) : null}
             </div>
           ) : null}
         </div>
@@ -271,35 +231,6 @@ const Hero = ({ data }) => {
                     aria-label={fact.cta.ariaLabel || fact.cta.label}
                   >
                     {fact.cta.label}
-                  </a>
-                ) : null}
-              </article>
-            ))}
-          </div>
-        ) : null}
-
-        {Array.isArray(qualifiers) && qualifiers.length > 0 ? (
-          <div className="hero__qualifiers" role="list">
-            {qualifiers.map((qualifier) => (
-              <article
-                key={qualifier.title}
-                className="hero__qualifier hero__glass hero__glass--soft"
-                role="listitem"
-              >
-                {qualifier.tag ? (
-                  <span className="hero__qualifier-tag hero__badge hero__badge--outline">
-                    {qualifier.tag}
-                  </span>
-                ) : null}
-                <h2 className="hero__qualifier-title">{qualifier.title}</h2>
-                {qualifier.description ? <p className="hero__qualifier-description">{qualifier.description}</p> : null}
-                {qualifier.cta ? (
-                  <a
-                    className="hero__qualifier-cta"
-                    href={qualifier.cta.href}
-                    aria-label={qualifier.cta.ariaLabel || qualifier.cta.label}
-                  >
-                    {qualifier.cta.label}
                   </a>
                 ) : null}
               </article>
@@ -346,16 +277,6 @@ const Hero = ({ data }) => {
               ) : null}
             </div>
           ) : null}
-
-          {Array.isArray(logos) && logos.length > 0 ? (
-            <div className="hero__logos" aria-label="Партнеры и дисциплины">
-              {logos.map((logo) => (
-                <span key={logo} className="hero__logo-chip">
-                  {logo}
-                </span>
-              ))}
-            </div>
-          ) : null}
         </footer>
       </div>
     </div>
@@ -381,36 +302,6 @@ Hero.propTypes = {
       left: PropTypes.string,
       right: PropTypes.string,
     }),
-    match: PropTypes.shape({
-      left: PropTypes.shape({
-        code: PropTypes.string.isRequired,
-        name: PropTypes.string.isRequired,
-        note: PropTypes.string,
-      }),
-      right: PropTypes.shape({
-        code: PropTypes.string.isRequired,
-        name: PropTypes.string.isRequired,
-        note: PropTypes.string,
-      }),
-    }),
-    tabs: PropTypes.arrayOf(
-      PropTypes.shape({
-        label: PropTypes.string.isRequired,
-        href: PropTypes.string.isRequired,
-      })
-    ),
-    qualifiers: PropTypes.arrayOf(
-      PropTypes.shape({
-        tag: PropTypes.string,
-        title: PropTypes.string.isRequired,
-        description: PropTypes.string,
-        cta: PropTypes.shape({
-          label: PropTypes.string.isRequired,
-          href: PropTypes.string.isRequired,
-          ariaLabel: PropTypes.string,
-        }),
-      })
-    ),
     prize: PropTypes.shape({
       label: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired,
@@ -421,7 +312,6 @@ Hero.propTypes = {
       expiredLabel: PropTypes.string,
       fallbackLabel: PropTypes.string,
     }),
-    logos: PropTypes.arrayOf(PropTypes.string),
     media: PropTypes.shape({
       disableOnMobile: PropTypes.bool,
       poster: PropTypes.string,

--- a/src/features/Hero/config.json
+++ b/src/features/Hero/config.json
@@ -4,9 +4,8 @@
     "label": "YarCyberSeason",
     "seasonLabel": "Сезон 2025/26",
     "links": [
-      { "label": "Календарь", "href": "#schedule" },
-      { "label": "Дивизионы", "href": "#divisions" },
-      { "label": "Партнёры", "href": "#sponsors" }
+      { "label": "Регламент сезона", "href": "/docs/ycs-cup-2025-26.pdf" },
+      { "label": "FAQ", "href": "#faq" }
     ]
   },
   "primaryCta": {
@@ -36,95 +35,49 @@
     "left": "https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1100&q=80",
     "right": "https://images.unsplash.com/photo-1516905041604-7935af78f573?auto=format&fit=crop&w=1100&q=80"
   },
-  "match": {
-    "left": {
-      "code": "OPEN",
-      "name": "Открытая лига",
-      "note": "Онлайн-отборы осень 2025"
-    },
-    "right": {
-      "code": "LAN",
-      "name": "Гранд-финал",
-      "note": "Май 2026, Ярославль"
-    }
-  },
-  "tabs": [
-    { "label": "Открытая лига", "href": "#division-open" },
-    { "label": "Студенческий дивизион", "href": "#division-students" },
-    { "label": "Школьный дивизион", "href": "#division-school" }
-  ],
   "keyFacts": [
     {
-      "tag": "OPEN",
-      "title": "Открытая лига",
-      "value": "Регистрация до 12 сентября",
-      "description": "Онлайн-отборочные раунды стартуют 15 сентября 2025 года. 256 слотов для полупрофессиональных составов.",
+      "tag": "QUAL",
+      "title": "Регистрация на квалификацию",
+      "value": "до 12 сентября 2025",
+      "description": "Подайте общую заявку, чтобы попасть в онлайн-квалификацию сезона по CS2 и Dota 2.",
       "cta": {
-        "label": "Регистрация OPEN",
-        "href": "/register/open",
-        "ariaLabel": "Зарегистрировать команду в открытой лиге"
+        "label": "Заполнить заявку",
+        "href": "/forms/qualification",
+        "ariaLabel": "Открыть форму регистрации на квалификацию YarCyberSeason"
       }
     },
     {
-      "tag": "STUDENT",
-      "title": "Студенческий дивизион",
-      "value": "Регистрация до 19 сентября",
-      "description": "Кампус-лиги университетов региона. Отборочные стадии проходят в онлайн-формате, финал в декабре 2025 года.",
+      "tag": "DOTA 2",
+      "title": "Основной этап Dota 2",
+      "value": "15–28 октября 2025",
+      "description": "Групповой этап и плей-офф среди лучших команд квалификации. Матчи проходят онлайн по будням.",
       "cta": {
-        "label": "Регистрация STUDENT",
-        "href": "/register/student",
-        "ariaLabel": "Зарегистрировать команду студенческого дивизиона"
+        "label": "Регламент Dota 2",
+        "href": "/docs/ycs-dota2-mainstage.pdf",
+        "ariaLabel": "Открыть регламент основного этапа Dota 2"
       }
     },
     {
-      "tag": "SCHOOL",
-      "title": "Школьный дивизион",
-      "value": "Регистрация до 26 сентября",
-      "description": "Командные баталии для школьников 8-11 классов. Старт онлайн-групп — 29 сентября, финал в январе 2026 года.",
+      "tag": "CS2",
+      "title": "Основной этап CS2",
+      "value": "5–20 ноября 2025",
+      "description": "Студенческие и открытые составы борются за слоты в офлайн-плей-офф. Формат – best-of-three.",
       "cta": {
-        "label": "Регистрация SCHOOL",
-        "href": "/register/school",
-        "ariaLabel": "Зарегистрировать школьную команду"
+        "label": "Регламент CS2",
+        "href": "/docs/ycs-cs2-mainstage.pdf",
+        "ariaLabel": "Открыть регламент основного этапа CS2"
       }
     },
     {
       "tag": "LAN",
-      "title": "Финальный фестиваль",
+      "title": "Гранд-финал YCS CUP",
       "value": "24 мая 2026",
-      "description": "Лучшие команды всех дивизионов встретятся на офлайн-сцене в Ярославле, чтобы побороться за кубок сезона и призовой фонд.",
+      "description": "Офлайн-фестиваль в Ярославле: финальные матчи, фан-зона и награждение чемпионов сезона.",
       "cta": {
-        "label": "Получить приглашение",
-        "href": "/final",
-        "ariaLabel": "Узнать подробнее о финальном фестивале"
-      }
-    }
-  ],
-  "qualifiers": [
-    {
-      "tag": "OPEN",
-      "title": "Онлайн-квалификация OPEN",
-      "description": "15–22 сентября 2025 • форматы CS2 и Dota 2",
-      "cta": {
-        "label": "Регистрация OPEN",
-        "href": "/register/open"
-      }
-    },
-    {
-      "tag": "STUDENT",
-      "title": "Кампус-лиги",
-      "description": "3–12 октября 2025 • гибридный формат с офлайн-плей-офф",
-      "cta": {
-        "label": "Заявка STUDENT",
-        "href": "/register/student"
-      }
-    },
-    {
-      "tag": "SCHOOL",
-      "title": "Школьные онлайн-группы",
-      "description": "29 сентября – 10 ноября 2025 • вечерние матчи",
-      "cta": {
-        "label": "Заявка SCHOOL",
-        "href": "/register/school"
+        "label": "Регламент LAN",
+        "href": "/docs/ycs-grand-final.pdf",
+        "ariaLabel": "Открыть регламент гранд-финала YarCyberSeason"
       }
     }
   ],
@@ -137,12 +90,5 @@
     "deadline": "2025-09-15T18:00:00+03:00",
     "expiredLabel": "Сезон начался",
     "fallbackLabel": "Следите за расписанием"
-  },
-  "logos": [
-    "YCS",
-    "CS2",
-    "Dota 2",
-    "Valorant",
-    "Rocket League"
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- simplify the Hero component to focus on branding, CTA and key facts while dropping the matchup, qualifiers, logos and tab UI
- refresh the Hero styles to support the streamlined layout, quick links and revised grid
- update the Hero configuration with the new quick links and four revised key fact cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f883df97b0832383ce144eecfaa3c8