### PR TITLE
feat: add partner support block to hero countdown

### DIFF
--- a/src/features/Hero/Hero.css
+++ b/src/features/Hero/Hero.css
@@ -406,8 +406,9 @@
 }
 
 .hero__countdown {
-  display: grid;
-  gap: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
   padding: var(--space-3);
   border-radius: var(--radius-lg);
   background: rgba(13, 18, 40, 0.85);
@@ -415,11 +416,52 @@
   min-width: min(320px, 100%);
 }
 
+.hero__countdown-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
 .hero__countdown-label {
   font-size: 0.85rem;
   text-transform: uppercase;
   letter-spacing: 0.24em;
   color: var(--color-secondary);
+}
+
+.hero__support {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(139, 123, 255, 0.32);
+  background: rgba(139, 123, 255, 0.16);
+  color: var(--color-text-secondary);
+  font-size: 0.72rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.hero__support-label {
+  white-space: nowrap;
+}
+
+.hero__support-logos {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.hero__support-logo {
+  display: block;
+  height: 28px;
+  width: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 4px 8px rgba(9, 14, 32, 0.45));
 }
 
 .hero__countdown-grid {
@@ -474,6 +516,10 @@
     gap: var(--space-5);
   }
 
+  .hero__countdown-header {
+    gap: var(--space-2);
+  }
+
   .hero__countdown-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -521,6 +567,25 @@
     min-width: 100%;
   }
 
+  .hero__countdown-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
+  .hero__support {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+  }
+
+  .hero__support-logos {
+    width: 100%;
+    justify-content: flex-start;
+    gap: var(--space-1);
+  }
+
   .hero__quicklinks {
     width: 100%;
   }
@@ -535,6 +600,10 @@
 @media (max-width: 540px) {
   .hero__title {
     font-size: clamp(2rem, 8vw, 2.8rem);
+  }
+
+  .hero__support-logo {
+    height: 24px;
   }
 }
 

--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import msLogo from './ms.png';
+import fksLogo from './fks.png';
 import './Hero.css';
 
 const DEFAULT_EXPIRED_LABEL = 'Сезон уже стартовал';
@@ -248,7 +250,20 @@ const Hero = ({ data }) => {
 
           {timer?.deadline ? (
             <div className="hero__countdown" aria-live="polite">
-              <span className="hero__countdown-label">{timer.label}</span>
+              <div className="hero__countdown-header">
+                <span className="hero__countdown-label">{timer.label}</span>
+                <div className="hero__support" aria-label="При поддержке">
+                  <span className="hero__support-label">при поддержке</span>
+                  <div className="hero__support-logos" role="group" aria-label="Логотипы партнеров">
+                    <img className="hero__support-logo" src={msLogo} alt="Microsoft" />
+                    <img
+                      className="hero__support-logo"
+                      src={fksLogo}
+                      alt="Федерация компьютерного спорта"
+                    />
+                  </div>
+                </div>
+              </div>
               {countdownUnavailable ? (
                 <span className="hero__countdown-status">{timerUnavailableLabel}</span>
               ) : timeLeft ? (


### PR DESCRIPTION
## Summary
- add a partner support section with Microsoft and FKS logos beside the hero countdown label
- adjust countdown layout styles so the support block aligns on desktop and wraps cleanly on mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f9d9878ec883238293716b55a45d16