### PR TITLE
fix: reposition hero support block beside countdown

### DIFF
--- a/src/features/Hero/Hero.css
+++ b/src/features/Hero/Hero.css
@@ -405,14 +405,26 @@
   font-weight: 700;
 }
 
-.hero__countdown {
-  display: grid;
-  gap: var(--space-2);
+
+.hero__countdown,
+.hero__support {
+  flex: 1 1 min(320px, 100%);
+  min-width: min(320px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
   padding: var(--space-3);
   border-radius: var(--radius-lg);
   background: rgba(13, 18, 40, 0.85);
   border: 1px solid rgba(64, 232, 194, 0.25);
-  min-width: min(320px, 100%);
+}
+
+.hero__countdown-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--space-3);
 }
 
 .hero__countdown-label {
@@ -420,6 +432,33 @@
   text-transform: uppercase;
   letter-spacing: 0.24em;
   color: var(--color-secondary);
+}
+
+.hero__support {
+  border-color: rgba(139, 123, 255, 0.35);
+  background: rgba(139, 123, 255, 0.16);
+}
+
+.hero__support-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  color: var(--color-text-secondary);
+}
+
+.hero__support-logos {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.hero__support-logo {
+  display: block;
+  height: 32px;
+  width: auto;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 18px rgba(9, 14, 32, 0.45));
 }
 
 .hero__countdown-grid {
@@ -474,6 +513,10 @@
     gap: var(--space-5);
   }
 
+  .hero__countdown-header {
+    gap: var(--space-2);
+  }
+
   .hero__countdown-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -516,9 +559,26 @@
     grid-template-columns: 1fr;
   }
 
-  .hero__countdown {
+  .hero__countdown,
+  .hero__support {
     width: 100%;
     min-width: 100%;
+  }
+
+  .hero__countdown-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
+  .hero__support {
+    align-items: flex-start;
+  }
+
+  .hero__support-logos {
+    width: 100%;
+    justify-content: flex-start;
+    gap: var(--space-2);
   }
 
   .hero__quicklinks {
@@ -535,6 +595,10 @@
 @media (max-width: 540px) {
   .hero__title {
     font-size: clamp(2rem, 8vw, 2.8rem);
+  }
+
+  .hero__support-logo {
+    height: 24px;
   }
 }
 

--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import msLogo from './ms.png';
+import fksLogo from './fks.png';
 import './Hero.css';
 
 const DEFAULT_EXPIRED_LABEL = 'Сезон уже стартовал';
@@ -248,7 +250,9 @@ const Hero = ({ data }) => {
 
           {timer?.deadline ? (
             <div className="hero__countdown" aria-live="polite">
-              <span className="hero__countdown-label">{timer.label}</span>
+              <div className="hero__countdown-header">
+                <span className="hero__countdown-label">{timer.label}</span>
+              </div>
               {countdownUnavailable ? (
                 <span className="hero__countdown-status">{timerUnavailableLabel}</span>
               ) : timeLeft ? (
@@ -277,6 +281,17 @@ const Hero = ({ data }) => {
               ) : null}
             </div>
           ) : null}
+          <div className="hero__support" aria-label="При поддержке">
+            <span className="hero__support-label">при поддержке</span>
+            <div className="hero__support-logos" role="group" aria-label="Логотипы партнеров">
+              <img className="hero__support-logo" src={msLogo} alt="Microsoft" />
+              <img
+                className="hero__support-logo"
+                src={fksLogo}
+                alt="Федерация компьютерного спорта"
+              />
+            </div>
+          </div>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- keep the partner support section with Microsoft and FKS logos but render it as a standalone card next to the hero countdown
- refine countdown and support layout styles so the two cards align on desktop and stack cleanly on mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f9d9878ec883238293716b55a45d16