### PR TITLE
Fix hero timing layout for countdown and support cards

### DIFF
--- a/src/features/Hero/Hero.css
+++ b/src/features/Hero/Hero.css
@@ -406,6 +406,16 @@
 }
 
 
+.hero__timing {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: clamp(var(--space-3), 3vw, var(--space-4));
+  flex: 1 1 clamp(320px, 55vw, 520px);
+  min-width: min(320px, 100%);
+}
+
+
 .hero__countdown {
 
   display: flex;
@@ -454,6 +464,9 @@
   letter-spacing: 0.2em;
   text-transform: uppercase;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  width: fit-content;
+  max-width: 100%;
+  align-self: stretch;
 }
 
 .hero__support-label {
@@ -574,6 +587,12 @@
 
   .hero__keyfacts {
     grid-template-columns: 1fr;
+  }
+
+  .hero__timing {
+    grid-template-columns: 1fr;
+    width: 100%;
+    min-width: 100%;
   }
 
   .hero__countdown,

--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -248,61 +248,63 @@ const Hero = ({ data }) => {
             </div>
           ) : null}
 
-          {timer?.deadline ? (
-            <div className="hero__countdown" aria-live="polite">
-              <div className="hero__countdown-header">
-                <span className="hero__countdown-label">{timer.label}</span>
+          <div className="hero__timing">
+            {timer?.deadline ? (
+              <div className="hero__countdown" aria-live="polite">
+                <div className="hero__countdown-header">
+                  <span className="hero__countdown-label">{timer.label}</span>
 
-                <div className="hero__support" aria-label="При поддержке">
-                  <span className="hero__support-label">при поддержке</span>
-                  <div className="hero__support-logos" role="group" aria-label="Логотипы партнеров">
-                    <img className="hero__support-logo" src={msLogo} alt="Microsoft" />
-                    <img
-                      className="hero__support-logo"
-                      src={fksLogo}
-                      alt="Федерация компьютерного спорта"
-                    />
+                  <div className="hero__support" aria-label="При поддержке">
+                    <span className="hero__support-label">при поддержке</span>
+                    <div className="hero__support-logos" role="group" aria-label="Логотипы партнеров">
+                      <img className="hero__support-logo" src={msLogo} alt="Microsoft" />
+                      <img
+                        className="hero__support-logo"
+                        src={fksLogo}
+                        alt="Федерация компьютерного спорта"
+                      />
+                    </div>
                   </div>
+
                 </div>
-
+                {countdownUnavailable ? (
+                  <span className="hero__countdown-status">{timerUnavailableLabel}</span>
+                ) : timeLeft ? (
+                  timeLeft.expired ? (
+                    <span className="hero__countdown-status">{timerExpiredLabel}</span>
+                  ) : (
+                    <div className="hero__countdown-grid" role="group" aria-label="Обратный отсчет до старта">
+                      <div className="hero__countdown-segment">
+                        <span className="hero__countdown-value">{timeLeft.days}</span>
+                        <span className="hero__countdown-unit">дни</span>
+                      </div>
+                      <div className="hero__countdown-segment">
+                        <span className="hero__countdown-value">{timeLeft.hours}</span>
+                        <span className="hero__countdown-unit">часы</span>
+                      </div>
+                      <div className="hero__countdown-segment">
+                        <span className="hero__countdown-value">{timeLeft.minutes}</span>
+                        <span className="hero__countdown-unit">минуты</span>
+                      </div>
+                      <div className="hero__countdown-segment">
+                        <span className="hero__countdown-value">{timeLeft.seconds}</span>
+                        <span className="hero__countdown-unit">секунды</span>
+                      </div>
+                    </div>
+                  )
+                ) : null}
               </div>
-              {countdownUnavailable ? (
-                <span className="hero__countdown-status">{timerUnavailableLabel}</span>
-              ) : timeLeft ? (
-                timeLeft.expired ? (
-                  <span className="hero__countdown-status">{timerExpiredLabel}</span>
-                ) : (
-                  <div className="hero__countdown-grid" role="group" aria-label="Обратный отсчет до старта">
-                    <div className="hero__countdown-segment">
-                      <span className="hero__countdown-value">{timeLeft.days}</span>
-                      <span className="hero__countdown-unit">дни</span>
-                    </div>
-                    <div className="hero__countdown-segment">
-                      <span className="hero__countdown-value">{timeLeft.hours}</span>
-                      <span className="hero__countdown-unit">часы</span>
-                    </div>
-                    <div className="hero__countdown-segment">
-                      <span className="hero__countdown-value">{timeLeft.minutes}</span>
-                      <span className="hero__countdown-unit">минуты</span>
-                    </div>
-                    <div className="hero__countdown-segment">
-                      <span className="hero__countdown-value">{timeLeft.seconds}</span>
-                      <span className="hero__countdown-unit">секунды</span>
-                    </div>
-                  </div>
-                )
-              ) : null}
-            </div>
-          ) : null}
-          <div className="hero__support" aria-label="При поддержке">
-            <span className="hero__support-label">при поддержке</span>
-            <div className="hero__support-logos" role="group" aria-label="Логотипы партнеров">
-              <img className="hero__support-logo" src={msLogo} alt="Microsoft" />
-              <img
-                className="hero__support-logo"
-                src={fksLogo}
-                alt="Федерация компьютерного спорта"
-              />
+            ) : null}
+            <div className="hero__support" aria-label="При поддержке">
+              <span className="hero__support-label">при поддержке</span>
+              <div className="hero__support-logos" role="group" aria-label="Логотипы партнеров">
+                <img className="hero__support-logo" src={msLogo} alt="Microsoft" />
+                <img
+                  className="hero__support-logo"
+                  src={fksLogo}
+                  alt="Федерация компьютерного спорта"
+                />
+              </div>
             </div>
           </div>
         </footer>


### PR DESCRIPTION
## Summary
- wrap the hero footer countdown and support blocks in a hero__timing container so they can share a grid layout
- update hero__timing and hero__support styling to use flexible grid columns and fit-content sizing while stretching to match heights
- restore single-column stacking and full-width support card behavior in the mobile breakpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9f042388c8323bb389d28884b19fc