### PR TITLE
Fix hero support logos layout

### DIFF
--- a/src/features/Hero/Hero.css
+++ b/src/features/Hero/Hero.css
@@ -452,41 +452,35 @@
 
 .hero__support {
   display: grid;
-  grid-template-rows: auto 1fr;
-  align-items: center;
   gap: var(--space-2);
-  padding: 0.4rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid rgba(139, 123, 255, 0.32);
-  background: rgba(139, 123, 255, 0.16);
-  color: var(--color-text-secondary);
-  font-size: 0.72rem;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
-  width: fit-content;
-  max-width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: rgba(139, 123, 255, 0.12);
+  border: 1px solid rgba(139, 123, 255, 0.35);
+  align-content: start;
   align-self: stretch;
 }
 
 .hero__support-label {
-  white-space: nowrap;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
 }
 
 .hero__support-logos {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  display: flex;
   align-items: center;
-  gap: var(--space-2);
-  grid-auto-rows: 1fr;
-  height: 100%;
+  justify-content: center;
+  gap: clamp(var(--space-2), 2vw, var(--space-4));
+  flex-wrap: wrap;
 }
 
 .hero__support-logo {
   display: block;
-  width: 100%;
-  height: 100%;
-  padding: 0.2rem;
+  max-height: 100px;
+  width: auto;
+  height: auto;
   object-fit: contain;
   filter: drop-shadow(0 4px 8px rgba(9, 14, 32, 0.45));
 }
@@ -608,14 +602,18 @@
   }
 
   .hero__support {
-    width: 100%;
-    grid-template-rows: auto auto;
-    gap: var(--space-1);
+    text-align: center;
+    justify-items: center;
+    gap: var(--space-2);
   }
 
   .hero__support-logos {
-    width: 100%;
-    gap: var(--space-1);
+    justify-content: center;
+    gap: var(--space-2);
+  }
+
+  .hero__support-label {
+    justify-self: center;
   }
 
   .hero__quicklinks {
@@ -635,11 +633,11 @@
   }
 
   .hero__support-logos {
-    grid-template-columns: 1fr;
+    gap: var(--space-1);
   }
 
   .hero__support-logo {
-    padding: 0.15rem 0;
+    max-height: 50px;
   }
 }
 

--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -253,19 +253,6 @@ const Hero = ({ data }) => {
               <div className="hero__countdown" aria-live="polite">
                 <div className="hero__countdown-header">
                   <span className="hero__countdown-label">{timer.label}</span>
-
-                  <div className="hero__support" aria-label="При поддержке">
-                    <span className="hero__support-label">при поддержке</span>
-                    <div className="hero__support-logos" role="group" aria-label="Логотипы партнеров">
-                      <img className="hero__support-logo" src={msLogo} alt="Microsoft" />
-                      <img
-                        className="hero__support-logo"
-                        src={fksLogo}
-                        alt="Федерация компьютерного спорта"
-                      />
-                    </div>
-                  </div>
-
                 </div>
                 {countdownUnavailable ? (
                   <span className="hero__countdown-status">{timerUnavailableLabel}</span>
@@ -295,7 +282,7 @@ const Hero = ({ data }) => {
                 ) : null}
               </div>
             ) : null}
-            <div className="hero__support" aria-label="При поддержке">
+            <div className="hero__support" aria-label="Партнеры сезона">
               <span className="hero__support-label">при поддержке</span>
               <div className="hero__support-logos" role="group" aria-label="Логотипы партнеров">
                 <img className="hero__support-logo" src={msLogo} alt="Microsoft" />


### PR DESCRIPTION
## Summary
- remove duplicated support badges from countdown header
- add a single support card styled like the prize fund block and center partner logos
- cap partner logo height at 100px on desktop and 50px on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9f6895f008323bb101e23852aeed1