### PR TITLE
fix: limit registration deadline width

### DIFF
--- a/src/features/RegistrationCta/RegistrationCta.css
+++ b/src/features/RegistrationCta/RegistrationCta.css
@@ -58,6 +58,7 @@
   border-radius: var(--radius-lg);
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(64, 232, 194, 0.2);
+  width: min(20vw, 100%);
 }
 
 .registration-cta__deadline-label {
@@ -266,6 +267,10 @@
 @media (max-width: 1024px) {
   .registration-cta__header {
     flex-direction: column;
+  }
+
+  .registration-cta__deadline {
+    width: 100%;
   }
 
   .registration-cta__actions {


### PR DESCRIPTION
## Summary
- constrain the registration countdown block so it does not exceed 20% of the viewport width
- reset the countdown width to full width on tablet and smaller layouts to keep it readable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f9fbd71ef08323ab57e54ac952bbf8