### PR TITLE
feat: refactor hero footer layout

### DIFF
--- a/src/features/Hero/Hero.css
+++ b/src/features/Hero/Hero.css
@@ -378,16 +378,26 @@
 }
 
 .hero__footer {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: clamp(var(--space-3), 3vw, var(--space-5));
-  align-items: center;
+  align-items: stretch;
+}
+
+.hero__footer-item {
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+
+.hero__footer-item > * {
+  flex: 1 1 auto;
 }
 
 .hero__stat {
   display: grid;
   gap: var(--space-1);
-  padding: var(--space-3) var(--space-4);
+  padding: clamp(var(--space-3), 3vw, var(--space-4));
   border-radius: var(--radius-md);
   background: rgba(139, 123, 255, 0.12);
   border: 1px solid rgba(139, 123, 255, 0.35);
@@ -406,25 +416,26 @@
 }
 
 
-.hero__timing {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: stretch;
-  gap: clamp(var(--space-3), 3vw, var(--space-4));
-  flex: 1 1 clamp(320px, 55vw, 520px);
-  min-width: min(320px, 100%);
-}
-
-
 .hero__countdown {
-
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
-  padding: var(--space-3);
+  padding: clamp(var(--space-3), 3vw, var(--space-4));
   border-radius: var(--radius-lg);
   background: rgba(13, 18, 40, 0.85);
   border: 1px solid rgba(64, 232, 194, 0.25);
+}
+
+.hero__countdown-status {
+  display: block;
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.05);
+  text-align: center;
+  font-size: clamp(0.95rem, 0.9rem + 0.3vw, 1.05rem);
+  line-height: 1.4;
+  color: var(--color-text-secondary);
+  text-wrap: pretty;
 }
 
 .hero__countdown-header {
@@ -453,7 +464,7 @@
 .hero__support {
   display: grid;
   gap: var(--space-2);
-  padding: var(--space-3) var(--space-4);
+  padding: clamp(var(--space-3), 3vw, var(--space-4));
   border-radius: var(--radius-md);
   background: rgba(139, 123, 255, 0.12);
   border: 1px solid rgba(139, 123, 255, 0.35);
@@ -537,6 +548,29 @@
     gap: var(--space-5);
   }
 
+  .hero__footer {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero__countdown {
+    align-items: center;
+    text-align: center;
+  }
+
+  .hero__countdown-header {
+    justify-content: center;
+    text-align: center;
+  }
+
+  .hero__support {
+    text-align: center;
+    justify-items: center;
+  }
+
+  .hero__support-logos {
+    justify-content: center;
+  }
+
   .hero__countdown-header {
     gap: var(--space-2);
   }
@@ -569,6 +603,10 @@
     gap: var(--space-4);
   }
 
+  .hero__footer {
+    grid-template-columns: 1fr;
+  }
+
   .hero__topbar {
     flex-direction: column;
     align-items: flex-start;
@@ -583,21 +621,9 @@
     grid-template-columns: 1fr;
   }
 
-  .hero__timing {
-    grid-template-columns: 1fr;
-    width: 100%;
-    min-width: 100%;
-  }
-
-  .hero__countdown,
-  .hero__support {
-    width: 100%;
-    min-width: 100%;
-  }
-
   .hero__countdown-header {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     gap: var(--space-2);
   }
 

--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -242,14 +242,16 @@ const Hero = ({ data }) => {
 
         <footer className="hero__footer">
           {prize ? (
-            <div className="hero__stat">
-              <span className="hero__stat-label">{prize.label}</span>
-              <span className="hero__stat-value">{prize.value}</span>
+            <div className="hero__footer-item">
+              <div className="hero__stat">
+                <span className="hero__stat-label">{prize.label}</span>
+                <span className="hero__stat-value">{prize.value}</span>
+              </div>
             </div>
           ) : null}
 
-          <div className="hero__timing">
-            {timer?.deadline ? (
+          {timer?.deadline ? (
+            <div className="hero__footer-item">
               <div className="hero__countdown" aria-live="polite">
                 <div className="hero__countdown-header">
                   <span className="hero__countdown-label">{timer.label}</span>
@@ -281,7 +283,10 @@ const Hero = ({ data }) => {
                   )
                 ) : null}
               </div>
-            ) : null}
+            </div>
+          ) : null}
+
+          <div className="hero__footer-item">
             <div className="hero__support" aria-label="Партнеры сезона">
               <span className="hero__support-label">при поддержке</span>
               <div className="hero__support-logos" role="group" aria-label="Логотипы партнеров">


### PR DESCRIPTION
## Summary
- restructure the hero footer markup to expose dedicated grid cells for the prize, countdown, and support blocks
- convert the hero footer styling to CSS Grid with shared padding, centered content, and responsive breakpoints for three-, two-, and single-column layouts
- polish countdown status presentation to keep expired or fallback labels readable without breaking the grid

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fa072117a083239c378eec6f055b08