### PR TITLE
Remove season program section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,13 +4,11 @@ import Section from './components/Section.jsx';
 import Footer from './components/Footer.jsx';
 import Hero from './features/Hero/Hero.jsx';
 import Overview from './features/Overview/Overview.jsx';
-import Program from './features/Program/Program.jsx';
 import RegistrationCta from './features/RegistrationCta/RegistrationCta.jsx';
 import Stats from './features/Stats/Stats.jsx';
 import Sponsors from './features/Sponsors/Sponsors.jsx';
 import heroConfig from './features/Hero/config.json';
 import overviewConfig from './features/Overview/config.json';
-import programConfig from './features/Program/config.json';
 import registrationCtaConfig from './features/RegistrationCta/config.json';
 import statsConfig from './features/Stats/config.json';
 import sponsorsConfig from './features/Sponsors/config.json';
@@ -69,12 +67,6 @@ const App = () => {
       title: 'Ключевые показатели сезона',
       component: <Stats items={statsConfig} />,
       navLabel: 'Статистика',
-    },
-    {
-      id: 'program',
-      title: 'Программа сезона',
-      component: <Program sessions={programConfig} />,
-      navLabel: 'Программа',
     },
   ];
 


### PR DESCRIPTION
## Summary
- remove the season program section from the main app layout and navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fb348eac848323a03560ba0ba4a6f9