### PR TITLE
Add feminine theme toggle to YarCyberSeason site

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,6 +77,17 @@ const App = () => {
       label: section.navLabel,
     }));
 
+  const THEME_STORAGE_KEY = 'ycs-theme';
+
+  const getInitialTheme = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return 'default';
+    }
+
+    return window.localStorage.getItem(THEME_STORAGE_KEY) || 'default';
+  }, []);
+
+  const [theme, setTheme] = useState(getInitialTheme);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   useEffect(() => {
@@ -93,6 +104,19 @@ const App = () => {
     };
   }, [isMenuOpen]);
 
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const root = document.documentElement;
+    root.dataset.theme = theme;
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+    }
+  }, [theme]);
+
   const toggleMenu = () => {
     setIsMenuOpen((prev) => !prev);
   };
@@ -100,6 +124,12 @@ const App = () => {
   const handleNavLinkClick = () => {
     setIsMenuOpen(false);
   };
+
+  const handleThemeToggle = () => {
+    setTheme((prevTheme) => (prevTheme === 'feminine' ? 'default' : 'feminine'));
+  };
+
+  const isFeminineTheme = theme === 'feminine';
 
   return (
     <main className="app">
@@ -155,7 +185,7 @@ const App = () => {
           </Section>
         );
       })}
-      <Footer />
+      <Footer isFeminineTheme={isFeminineTheme} onThemeToggle={handleThemeToggle} />
     </main>
   );
 };

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -148,77 +148,79 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-3);
-  padding: 0.35rem 0.55rem;
-  border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  color: var(--color-text-secondary);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: radial-gradient(120% 120% at 0% 0%, rgba(154, 131, 255, 0.25) 0%, rgba(17, 26, 56, 0.75) 48%, rgba(10, 15, 34, 0.92) 100%);
+  color: var(--color-text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.footer__theme-toggle:hover,
+.footer__theme-toggle:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+  border-color: rgba(255, 255, 255, 0.28);
+}
+
+.footer__theme-toggle:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.45);
+  outline-offset: 3px;
+}
+
+.footer__theme-toggle--active {
+  background: linear-gradient(130deg, rgba(255, 169, 212, 0.65) 0%, rgba(141, 130, 255, 0.6) 45%, rgba(43, 23, 65, 0.95) 100%);
+  border-color: rgba(255, 169, 212, 0.6);
+  box-shadow: 0 12px 28px rgba(141, 130, 255, 0.35);
+}
+
+.footer__theme-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  font-size: 1.4rem;
+  transform: rotate(-8deg);
+  transition: transform var(--transition-fast), background var(--transition-fast);
+}
+
+.footer__theme-toggle:hover .footer__theme-icon,
+.footer__theme-toggle:focus-visible .footer__theme-icon,
+.footer__theme-toggle--active .footer__theme-icon {
+  background: rgba(255, 255, 255, 0.22);
+  transform: rotate(0deg);
 }
 
 .footer__theme-text {
   display: grid;
-  gap: 0.2rem;
+  gap: 0.25rem;
 }
 
 .footer__theme-label {
-  font-weight: 600;
+  font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  font-size: 0.7rem;
+  font-size: 0.75rem;
   color: var(--color-secondary);
 }
 
+.footer__theme-toggle--active .footer__theme-label {
+  color: #ffe4f6;
+}
+
 .footer__theme-description {
-  font-size: 0.75rem;
-  color: var(--color-text-muted);
+  font-size: 0.82rem;
+  color: var(--color-text-secondary);
 }
 
-.footer__switch {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  cursor: pointer;
-}
-
-.footer__switch-input {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-.footer__switch-indicator {
-  width: 52px;
-  height: 28px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  position: relative;
-  transition: background-color var(--transition-fast), border-color var(--transition-fast);
-}
-
-.footer__switch-indicator::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 4px;
-  transform: translate(0, -50%);
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: var(--gradient-primary);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-  transition: transform var(--transition-fast), background var(--transition-fast);
-}
-
-.footer__switch-input:checked + .footer__switch-indicator {
-  background: rgba(255, 255, 255, 0.22);
-  border-color: rgba(255, 255, 255, 0.4);
-}
-
-.footer__switch-input:checked + .footer__switch-indicator::after {
-  transform: translate(24px, -50%);
-  background: var(--gradient-secondary);
+.footer__theme-toggle--active .footer__theme-description {
+  color: rgba(255, 247, 253, 0.9);
 }
 
 @media (max-width: 1024px) {

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -132,8 +132,93 @@
 .footer__bottom {
   border-top: 1px solid rgba(255, 255, 255, 0.08);
   padding-top: var(--space-3);
+}
+
+.footer__bottom-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
   color: var(--color-text-muted);
   font-size: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.footer__theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 0.35rem 0.55rem;
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--color-text-secondary);
+}
+
+.footer__theme-text {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.footer__theme-label {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: var(--color-secondary);
+}
+
+.footer__theme-description {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+}
+
+.footer__switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.footer__switch-input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.footer__switch-indicator {
+  width: 52px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  position: relative;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.footer__switch-indicator::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 4px;
+  transform: translate(0, -50%);
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--gradient-primary);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  transition: transform var(--transition-fast), background var(--transition-fast);
+}
+
+.footer__switch-input:checked + .footer__switch-indicator {
+  background: rgba(255, 255, 255, 0.22);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.footer__switch-input:checked + .footer__switch-indicator::after {
+  transform: translate(24px, -50%);
+  background: var(--gradient-secondary);
 }
 
 @media (max-width: 1024px) {
@@ -149,5 +234,14 @@
 
   .footer__brand {
     justify-content: center;
+  }
+
+  .footer__bottom-inner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .footer__theme-toggle {
+    justify-content: space-between;
   }
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,8 @@
+import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 import './Footer.css';
 
-const Footer = () => {
+const Footer = ({ isFeminineTheme, onThemeToggle }) => {
   const currentYear = new Date().getFullYear();
   const [isEasterEggActive, setIsEasterEggActive] = useState(false);
 
@@ -88,12 +89,35 @@ const Footer = () => {
         </div>
       </div>
       <div className="footer__bottom">
-        <p className="footer__copyright">
-          © {currentYear} YarCyberSeason. Все права защищены.
-        </p>
+        <div className="footer__bottom-inner">
+          <p className="footer__copyright">
+            © {currentYear} YarCyberSeason. Все права защищены.
+          </p>
+          <div className="footer__theme-toggle">
+            <div className="footer__theme-text">
+              <span className="footer__theme-label">Женская версия</span>
+              <span className="footer__theme-description">Более мягкая цветовая палитра</span>
+            </div>
+            <label className="footer__switch">
+              <input
+                type="checkbox"
+                className="footer__switch-input"
+                checked={isFeminineTheme}
+                onChange={onThemeToggle}
+                aria-label="Переключить женскую версию сайта"
+              />
+              <span aria-hidden="true" className="footer__switch-indicator" />
+            </label>
+          </div>
+        </div>
       </div>
     </footer>
   );
+};
+
+Footer.propTypes = {
+  isFeminineTheme: PropTypes.bool.isRequired,
+  onThemeToggle: PropTypes.func.isRequired,
 };
 
 export default Footer;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -93,22 +93,22 @@ const Footer = ({ isFeminineTheme, onThemeToggle }) => {
           <p className="footer__copyright">
             © {currentYear} YarCyberSeason. Все права защищены.
           </p>
-          <div className="footer__theme-toggle">
-            <div className="footer__theme-text">
+          <button
+            type="button"
+            className={`footer__theme-toggle${isFeminineTheme ? ' footer__theme-toggle--active' : ''}`}
+            onClick={onThemeToggle}
+            aria-pressed={isFeminineTheme}
+          >
+            <span className="footer__theme-icon" aria-hidden="true">
+              {isFeminineTheme ? '🌸' : '🌺'}
+            </span>
+            <span className="footer__theme-text">
               <span className="footer__theme-label">Женская версия</span>
-              <span className="footer__theme-description">Более мягкая цветовая палитра</span>
-            </div>
-            <label className="footer__switch">
-              <input
-                type="checkbox"
-                className="footer__switch-input"
-                checked={isFeminineTheme}
-                onChange={onThemeToggle}
-                aria-label="Переключить женскую версию сайта"
-              />
-              <span aria-hidden="true" className="footer__switch-indicator" />
-            </label>
-          </div>
+              <span className="footer__theme-description">
+                {isFeminineTheme ? 'Нежная палитра активна' : 'Включить нежную палитру'}
+              </span>
+            </span>
+          </button>
         </div>
       </div>
     </footer>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -58,6 +58,38 @@
   --breakpoint-mobile: 768px;
 }
 
+:root[data-theme='feminine'] {
+  --color-bg: #160414;
+  --color-bg-alt: #220721;
+  --color-surface: rgba(54, 21, 56, 0.9);
+  --color-surface-strong: rgba(66, 29, 69, 0.94);
+  --color-card: rgba(56, 18, 52, 0.92);
+  --color-card-alt: rgba(76, 24, 68, 0.88);
+  --color-border: rgba(255, 154, 202, 0.24);
+  --color-border-strong: rgba(255, 154, 202, 0.48);
+  --color-shadow: 0 24px 64px rgba(45, 6, 31, 0.58);
+  --color-text-primary: #fff3fa;
+  --color-text-secondary: #ffd7ec;
+  --color-text-muted: #e0a8c6;
+  --color-primary: #ff86d1;
+  --color-primary-soft: rgba(255, 134, 209, 0.18);
+  --color-secondary: #ffb4ed;
+  --color-secondary-soft: rgba(255, 180, 237, 0.25);
+  --color-tertiary: #ffc7a5;
+  --color-tertiary-soft: rgba(255, 199, 165, 0.26);
+  --color-success: #ffdeeb;
+  --color-warning: #ffd174;
+  --color-danger: #ff8fa3;
+  --color-overlay: rgba(51, 12, 43, 0.6);
+  --color-glare: rgba(255, 255, 255, 0.08);
+
+  --gradient-primary: linear-gradient(130deg, rgba(255, 134, 209, 0.92), rgba(255, 199, 165, 0.9));
+  --gradient-secondary: linear-gradient(150deg, rgba(255, 180, 237, 0.9), rgba(255, 207, 177, 0.85));
+  --gradient-surface: linear-gradient(145deg, rgba(54, 21, 56, 0.9), rgba(76, 24, 68, 0.92));
+
+  color-scheme: dark;
+}
+
 html {
   scroll-behavior: smooth;
   background-color: var(--color-bg);
@@ -73,6 +105,14 @@ body {
     radial-gradient(circle at 50% 80%, rgba(255, 111, 207, 0.12), transparent 60%),
     linear-gradient(180deg, var(--color-bg) 0%, var(--color-bg-alt) 100%);
   background-attachment: fixed;
+}
+
+:root[data-theme='feminine'] body {
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 134, 209, 0.16), transparent 55%),
+    radial-gradient(circle at 80% 12%, rgba(255, 207, 177, 0.22), transparent 55%),
+    radial-gradient(circle at 55% 78%, rgba(255, 180, 237, 0.18), transparent 60%),
+    linear-gradient(180deg, var(--color-bg) 0%, var(--color-bg-alt) 100%);
 }
 
 body.app-barrel-roll {


### PR DESCRIPTION
## Summary
- add client-side theme persistence and expose a footer toggle for switching to the feminine palette
- define feminine theme color variables and supporting background styles
- update footer styling to accommodate the new toggle control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68feb1c1543c8323b601fd0f227d963c