### PR TITLE
Remove hero branding logo and tagline

### DIFF
--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -164,17 +164,16 @@ const Hero = ({ data }) => {
       </div>
       <div className="hero__overlay" aria-hidden="true" />
       <div className="hero__inner hero__inner--versus">
-        <header className="hero__topbar">
-          <div className="hero__brand">
-            <span className="hero__brand-mark" aria-hidden="true">
-              YCS
-            </span>
-            <div className="hero__brand-text">
-              {branding?.tagline ? <span className="hero__brand-tagline">{branding.tagline}</span> : null}
-              {branding?.label ? <span className="hero__brand-label">{branding.label}</span> : null}
+        {branding?.tagline || branding?.label ? (
+          <header className="hero__topbar">
+            <div className="hero__brand">
+              <div className="hero__brand-text">
+                {branding?.tagline ? <span className="hero__brand-tagline">{branding.tagline}</span> : null}
+                {branding?.label ? <span className="hero__brand-label">{branding.label}</span> : null}
+              </div>
             </div>
-          </div>
-        </header>
+          </header>
+        ) : null}
 
         <div className="hero__centerpiece">
           {branding?.seasonLabel ? (

--- a/src/features/Hero/config.json
+++ b/src/features/Hero/config.json
@@ -1,7 +1,5 @@
 {
   "branding": {
-    "tagline": "YCS CUP",
-    "label": "YarCyberSeason",
     "seasonLabel": "Сезон 2025/26",
     "links": [
       { "label": "Регламент сезона", "href": "/docs/ycs-cup-2025-26.pdf" },


### PR DESCRIPTION
## Summary
- remove the static hero brand mark so the logo no longer renders
- drop the YCS CUP and YarCyberSeason values from the hero configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ff9e5680548323b3dfdb8900e40ad0