### PR TITLE
feat: display support partner names with logos

### DIFF
--- a/src/features/Hero/Hero.css
+++ b/src/features/Hero/Hero.css
@@ -488,21 +488,38 @@
   color: var(--color-text-muted);
 }
 
+
 .hero__support-logos {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   justify-content: center;
-  gap: clamp(var(--space-2), 2vw, var(--space-4));
-  flex-wrap: wrap;
+  gap: clamp(var(--space-2), 2vw, var(--space-3));
+}
+
+.hero__support-partner {
+  display: flex;
+  align-items: center;
+  gap: clamp(var(--space-2), 1.5vw, var(--space-3));
+  padding: clamp(var(--space-2), 2vw, var(--space-3));
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: 0 12px 32px rgba(9, 14, 32, 0.25);
 }
 
 .hero__support-logo {
   display: block;
-  max-height: 100px;
+  max-height: 64px;
   width: auto;
   height: auto;
   object-fit: contain;
   filter: drop-shadow(0 4px 8px rgba(9, 14, 32, 0.45));
+}
+
+.hero__support-name {
+  font-weight: 600;
+  font-size: clamp(0.95rem, 1.5vw, 1.05rem);
+  color: var(--color-text-primary);
 }
 
 .hero__countdown-grid {
@@ -580,6 +597,11 @@
     justify-content: center;
   }
 
+  .hero__support-partner {
+    justify-content: center;
+    text-align: center;
+  }
+
   .hero__countdown-header {
     gap: var(--space-2);
   }
@@ -647,6 +669,10 @@
     gap: var(--space-2);
   }
 
+  .hero__support-partner {
+    flex-direction: column;
+  }
+
   .hero__support-label {
     justify-self: center;
   }
@@ -671,8 +697,12 @@
     gap: var(--space-1);
   }
 
+  .hero__support-partner {
+    padding: var(--space-2);
+  }
+
   .hero__support-logo {
-    max-height: 50px;
+    max-height: 56px;
   }
 }
 

--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -116,6 +116,21 @@ const Hero = ({ data }) => {
   const timerUnavailableLabel = timer?.fallbackLabel ?? timerExpiredLabel;
   const countdownUnavailable = timer?.deadline && timeLeft === null;
 
+  const supportPartners = [
+    {
+      id: 'microsoft',
+      logo: msLogo,
+      name: 'Microsoft',
+      alt: 'Microsoft',
+    },
+    {
+      id: 'fks',
+      logo: fksLogo,
+      name: 'Федерация компьютерного спорта',
+      alt: 'Федерация компьютерного спорта',
+    },
+  ];
+
   const videoSources = Array.isArray(media?.sources)
     ? media.sources.filter((source) => source && source.src)
     : [];
@@ -288,13 +303,13 @@ const Hero = ({ data }) => {
           <div className="hero__footer-item">
             <div className="hero__support" aria-label="Партнеры сезона">
               <span className="hero__support-label">при поддержке</span>
-              <div className="hero__support-logos" role="group" aria-label="Логотипы партнеров">
-                <img className="hero__support-logo" src={msLogo} alt="Microsoft" />
-                <img
-                  className="hero__support-logo"
-                  src={fksLogo}
-                  alt="Федерация компьютерного спорта"
-                />
+              <div className="hero__support-logos" role="list" aria-label="Партнеры сезона">
+                {supportPartners.map((partner) => (
+                  <div key={partner.id} className="hero__support-partner" role="listitem">
+                    <img className="hero__support-logo" src={partner.logo} alt={partner.alt} />
+                    <span className="hero__support-name">{partner.name}</span>
+                  </div>
+                ))}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add a structured partner list in the hero footer to render company names beside their logos
- style the hero support section so logo and text stay aligned across breakpoints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffa1cf107c832392bdf60a2eb9da01