### PR TITLE
feat: refresh sponsors section styling

### DIFF
--- a/src/features/Sponsors/Sponsors.css
+++ b/src/features/Sponsors/Sponsors.css
@@ -1,18 +1,21 @@
 .sponsors {
-  --sponsors-surface: rgba(20, 25, 40, 0.7);
-  --sponsors-surface-strong: rgba(28, 34, 52, 0.78);
-  --sponsors-border: rgba(255, 255, 255, 0.08);
-  --sponsors-border-strong: rgba(255, 255, 255, 0.18);
+  --sponsors-surface: rgba(27, 30, 51, 0.78);
+  --sponsors-surface-strong: rgba(35, 38, 64, 0.86);
+  --sponsors-border: rgba(255, 255, 255, 0.06);
+  --sponsors-border-strong: rgba(255, 255, 255, 0.16);
   --sponsors-text-primary: var(--color-text-primary);
-  --sponsors-text-secondary: rgba(203, 212, 236, 0.85);
-  --sponsors-text-muted: rgba(148, 163, 199, 0.65);
-  --sponsors-logo-bg: rgba(255, 255, 255, 0.04);
+  --sponsors-text-secondary: rgba(224, 232, 252, 0.92);
+  --sponsors-text-muted: rgba(176, 188, 220, 0.72);
+  --sponsors-logo-bg: rgba(255, 255, 255, 0.05);
   position: relative;
   display: grid;
   gap: clamp(var(--space-5), 4vw, var(--space-6));
   padding: clamp(var(--space-5), 6vw, var(--space-7));
   border-radius: clamp(2rem, 4vw, 3.2rem);
-  background: linear-gradient(150deg, rgba(10, 14, 26, 0.92), rgba(16, 23, 38, 0.88));
+  background:
+    radial-gradient(120% 120% at 0% 0%, rgba(151, 119, 255, 0.18), transparent 58%),
+    radial-gradient(90% 110% at 100% 10%, rgba(255, 104, 198, 0.12), transparent 55%),
+    linear-gradient(160deg, rgba(22, 26, 46, 0.92), rgba(20, 31, 48, 0.88));
   border: 1px solid var(--sponsors-border);
   box-shadow: 0 26px 64px rgba(5, 10, 24, 0.32);
   backdrop-filter: blur(18px);
@@ -48,21 +51,25 @@
 
 .sponsors__benefits {
   margin-top: var(--space-3);
-  padding: var(--space-3);
-  border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: clamp(1.2rem, 2.6vw, 1.8rem);
+  border-radius: clamp(1.4rem, 3vw, 2rem);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0))
+      padding-box,
+    linear-gradient(135deg, rgba(163, 129, 255, 0.58), rgba(92, 194, 255, 0.42)) border-box;
+  border: 1px solid transparent;
   display: grid;
-  gap: var(--space-2);
-  box-shadow: none;
+  gap: var(--space-3);
+  box-shadow: 0 18px 48px rgba(7, 15, 34, 0.28);
 }
 
 .sponsors__benefits-title {
   margin: 0;
-  font-size: 0.95rem;
-  letter-spacing: 0.16em;
+  font-size: 1rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.78);
+  color: rgba(255, 255, 255, 0.86);
+  font-weight: 700;
 }
 
 .sponsors__benefits-list {
@@ -78,20 +85,25 @@
   grid-template-columns: auto 1fr;
   gap: var(--space-2);
   align-items: start;
+  padding: 0.75rem 0.95rem;
+  border-radius: var(--radius-md);
+  background: rgba(10, 14, 33, 0.38);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .sponsors__benefit-marker {
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 999px;
-  background: var(--color-secondary);
+  background: linear-gradient(135deg, rgba(255, 143, 229, 0.95), rgba(127, 196, 255, 0.95));
   margin-top: 0.35rem;
-  opacity: 0.9;
+  box-shadow: 0 0 0 6px rgba(255, 255, 255, 0.05);
 }
 
 .sponsors__benefit-text {
   color: var(--sponsors-text-secondary);
-  line-height: 1.6;
+  line-height: 1.55;
+  font-weight: 600;
 }
 
 .sponsors__cta-group {
@@ -154,9 +166,9 @@
   gap: clamp(var(--space-3), 2vw, var(--space-4));
   padding: clamp(1.6rem, 3vw, 2.6rem);
   border-radius: clamp(1.6rem, 2.8vw, 2.4rem);
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: none;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 40px rgba(8, 12, 32, 0.28);
   backdrop-filter: blur(16px);
   transition: border-color var(--transition-fast), background-color var(--transition-fast);
 }
@@ -164,14 +176,14 @@
 .sponsors__panel:hover,
 .sponsors__panel:focus-within {
   border-color: var(--sponsors-border-strong);
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .sponsors__featured {
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.08);
   color: var(--sponsors-text-primary);
   gap: clamp(var(--space-4), 3vw, var(--space-5));
-  border-color: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.16);
 }
 
 .sponsors__featured-content {
@@ -195,29 +207,51 @@
 
 .sponsors__featured-highlights {
   display: grid;
-  gap: var(--space-2);
-  padding: 0;
+  gap: var(--space-3);
+  padding: clamp(1.1rem, 2.4vw, 1.8rem);
+  border-radius: clamp(1.4rem, 3vw, 2rem);
+  background:
+    linear-gradient(140deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0))
+      padding-box,
+    linear-gradient(140deg, rgba(255, 143, 229, 0.55), rgba(127, 196, 255, 0.4)) border-box;
+  border: 1px solid transparent;
+  box-shadow: 0 24px 48px rgba(10, 16, 36, 0.25);
+}
+
+.sponsors__featured-highlights-label {
   margin: 0;
+  font-size: 0.9rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.sponsors__featured-highlight-list {
+  display: grid;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
   list-style: none;
 }
 
 .sponsors__featured-highlight {
-  position: relative;
-  padding-left: 1.6rem;
-  font-size: 0.98rem;
-  color: var(--sponsors-text-secondary);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--space-2);
+  align-items: start;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--sponsors-text-primary);
 }
 
 .sponsors__featured-highlight::before {
   content: '';
-  position: absolute;
-  left: 0;
-  top: 0.4rem;
-  width: 0.65rem;
-  height: 0.65rem;
+  width: 12px;
+  height: 12px;
   border-radius: 999px;
-  background: var(--color-secondary);
-  box-shadow: none;
+  background: linear-gradient(135deg, rgba(255, 143, 229, 0.95), rgba(127, 196, 255, 0.95));
+  box-shadow: 0 0 0 6px rgba(255, 255, 255, 0.06);
+  margin-top: 0.35rem;
 }
 
 .sponsors__featured-stats {

--- a/src/features/Sponsors/config.json
+++ b/src/features/Sponsors/config.json
@@ -46,7 +46,7 @@
       "sponsors": [
         {
           "name": "Cherry RAiT",
-          "logo": "logo-cherry.jpg",
+          "logo": "../Hero/logo1.png",
           "url": "https://t.me/Talyutin",
           "alt": "Логотип Cherry RAiT"
         }


### PR DESCRIPTION
## Summary
- soften the sponsors section palette and panels for a calmer appearance
- highlight sponsor benefits with accent containers and clearer labels
- resolve local sponsor logos including Cherry RAiT logo shared with the hero section

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffb2b1e75c8323b2b8ad56661da33a