### PR TITLE
feat: refresh sponsors styling and assets

### DIFF
--- a/src/features/Sponsors/Sponsors.css
+++ b/src/features/Sponsors/Sponsors.css
@@ -1,20 +1,20 @@
 .sponsors {
-  --sponsors-surface: rgba(20, 25, 40, 0.7);
-  --sponsors-surface-strong: rgba(28, 34, 52, 0.78);
-  --sponsors-border: rgba(255, 255, 255, 0.08);
-  --sponsors-border-strong: rgba(255, 255, 255, 0.18);
+  --sponsors-surface: rgba(38, 32, 82, 0.72);
+  --sponsors-surface-strong: rgba(52, 44, 110, 0.82);
+  --sponsors-border: rgba(255, 255, 255, 0.06);
+  --sponsors-border-strong: rgba(214, 198, 255, 0.26);
   --sponsors-text-primary: var(--color-text-primary);
-  --sponsors-text-secondary: rgba(203, 212, 236, 0.85);
-  --sponsors-text-muted: rgba(148, 163, 199, 0.65);
+  --sponsors-text-secondary: rgba(218, 224, 255, 0.82);
+  --sponsors-text-muted: rgba(172, 184, 226, 0.62);
   --sponsors-logo-bg: rgba(255, 255, 255, 0.04);
   position: relative;
   display: grid;
   gap: clamp(var(--space-5), 4vw, var(--space-6));
   padding: clamp(var(--space-5), 6vw, var(--space-7));
   border-radius: clamp(2rem, 4vw, 3.2rem);
-  background: linear-gradient(150deg, rgba(10, 14, 26, 0.92), rgba(16, 23, 38, 0.88));
+  background: linear-gradient(165deg, rgba(30, 24, 68, 0.95), rgba(18, 22, 52, 0.92));
   border: 1px solid var(--sponsors-border);
-  box-shadow: 0 26px 64px rgba(5, 10, 24, 0.32);
+  box-shadow: 0 28px 70px rgba(6, 8, 32, 0.38);
   backdrop-filter: blur(18px);
   overflow: hidden;
   isolation: isolate;
@@ -47,22 +47,42 @@
 }
 
 .sponsors__benefits {
+  position: relative;
   margin-top: var(--space-3);
-  padding: var(--space-3);
+  padding: calc(var(--space-3) + 0.2rem);
   border-radius: var(--radius-lg);
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(
+    155deg,
+    rgba(84, 56, 152, 0.55),
+    rgba(42, 40, 98, 0.6)
+  );
+  border: 1px solid rgba(190, 180, 255, 0.32);
   display: grid;
-  gap: var(--space-2);
-  box-shadow: none;
+  gap: var(--space-3);
+  box-shadow: 0 20px 46px rgba(10, 8, 36, 0.45);
+  overflow: hidden;
+}
+
+.sponsors__benefits::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(130deg, rgba(255, 140, 236, 0.22), transparent 55%);
+  pointer-events: none;
+}
+
+.sponsors__benefits > * {
+  position: relative;
+  z-index: 1;
 }
 
 .sponsors__benefits-title {
   margin: 0;
-  font-size: 0.95rem;
-  letter-spacing: 0.16em;
+  font-size: 1.05rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.78);
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .sponsors__benefits-list {
@@ -77,21 +97,26 @@
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--space-2);
-  align-items: start;
+  align-items: center;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: rgba(18, 20, 46, 0.55);
+  border: 1px solid rgba(210, 214, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
 }
 
 .sponsors__benefit-marker {
-  width: 10px;
-  height: 10px;
+  width: 12px;
+  height: 12px;
   border-radius: 999px;
-  background: var(--color-secondary);
-  margin-top: 0.35rem;
-  opacity: 0.9;
+  background: linear-gradient(135deg, var(--color-secondary), rgba(255, 156, 236, 0.9));
+  box-shadow: 0 0 12px rgba(255, 156, 236, 0.55);
 }
 
 .sponsors__benefit-text {
-  color: var(--sponsors-text-secondary);
-  line-height: 1.6;
+  color: rgba(235, 238, 255, 0.92);
+  line-height: 1.55;
+  font-weight: 600;
 }
 
 .sponsors__cta-group {
@@ -154,24 +179,26 @@
   gap: clamp(var(--space-3), 2vw, var(--space-4));
   padding: clamp(1.6rem, 3vw, 2.6rem);
   border-radius: clamp(1.6rem, 2.8vw, 2.4rem);
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: none;
-  backdrop-filter: blur(16px);
-  transition: border-color var(--transition-fast), background-color var(--transition-fast);
+  background: rgba(36, 32, 78, 0.42);
+  border: 1px solid rgba(204, 196, 255, 0.22);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(18px);
+  transition: border-color var(--transition-fast), background-color var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 
 .sponsors__panel:hover,
 .sponsors__panel:focus-within {
   border-color: var(--sponsors-border-strong);
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(46, 40, 96, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
 }
 
 .sponsors__featured {
-  background: rgba(255, 255, 255, 0.06);
+  background: linear-gradient(160deg, rgba(84, 60, 156, 0.42), rgba(38, 34, 102, 0.48));
   color: var(--sponsors-text-primary);
   gap: clamp(var(--space-4), 3vw, var(--space-5));
-  border-color: rgba(255, 255, 255, 0.14);
+  border-color: rgba(214, 204, 255, 0.32);
 }
 
 .sponsors__featured-content {
@@ -188,7 +215,7 @@
 
 .sponsors__featured-description {
   margin: 0;
-  color: var(--sponsors-text-secondary);
+  color: rgba(230, 234, 255, 0.86);
   font-size: 1rem;
   line-height: 1.7;
 }
@@ -203,21 +230,24 @@
 
 .sponsors__featured-highlight {
   position: relative;
-  padding-left: 1.6rem;
+  padding: 0.75rem 1rem 0.75rem 2.4rem;
   font-size: 0.98rem;
-  color: var(--sponsors-text-secondary);
+  color: rgba(234, 236, 255, 0.9);
+  border-radius: 1rem;
+  background: rgba(22, 24, 52, 0.55);
+  border: 1px solid rgba(208, 204, 255, 0.18);
 }
 
 .sponsors__featured-highlight::before {
   content: '';
   position: absolute;
-  left: 0;
-  top: 0.4rem;
-  width: 0.65rem;
-  height: 0.65rem;
+  left: 1rem;
+  top: 1.05rem;
+  width: 0.7rem;
+  height: 0.7rem;
   border-radius: 999px;
-  background: var(--color-secondary);
-  box-shadow: none;
+  background: linear-gradient(135deg, var(--color-secondary), rgba(255, 156, 236, 0.9));
+  box-shadow: 0 0 12px rgba(255, 156, 236, 0.55);
 }
 
 .sponsors__featured-stats {
@@ -286,9 +316,10 @@
   position: relative;
   display: flex;
   border-radius: clamp(1.2rem, 2vw, 1.6rem);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: transparent;
-  transition: border-color var(--transition-fast), opacity var(--transition-fast);
+  border: 1px solid rgba(208, 204, 255, 0.18);
+  background: rgba(24, 22, 62, 0.48);
+  transition: border-color var(--transition-fast), opacity var(--transition-fast),
+    background-color var(--transition-fast);
 }
 
 .sponsors__logo-tile {
@@ -306,8 +337,9 @@
 
 .sponsors__logo-spot:hover,
 .sponsors__logo-spot:focus-within {
-  border-color: rgba(255, 255, 255, 0.22);
-  opacity: 0.85;
+  border-color: var(--sponsors-border-strong);
+  background: rgba(36, 32, 82, 0.55);
+  opacity: 0.9;
 }
 
 .sponsors__logo-tile:focus-visible {


### PR DESCRIPTION
## Summary
- soften the sponsors section palette to create a calmer presentation and accentuate partner highlights
- emphasise sponsor benefits with richer styling and update Cherry RAiT to use the official hero logo

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffb2b1e75c8323b2b8ad56661da33a