### PR TITLE
fix: improve hero readability and remove quicklinks

### DIFF
--- a/src/features/Hero/Hero.css
+++ b/src/features/Hero/Hero.css
@@ -225,7 +225,18 @@
 
 .hero__subtitle {
   margin: 0;
-  color: inherit;
+  color: var(--color-text-primary);
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  flex-wrap: wrap;
+  padding: clamp(var(--space-3), 2.2vw, var(--space-4)) clamp(var(--space-4), 3vw, var(--space-5));
+  border-radius: clamp(1rem, 1.8vw, 1.6rem);
+  background: linear-gradient(135deg, rgba(9, 14, 32, 0.78), rgba(14, 24, 48, 0.72));
+  border: 1px solid rgba(139, 123, 255, 0.24);
+  box-shadow: 0 24px 60px rgba(5, 9, 26, 0.45);
+  backdrop-filter: blur(18px);
+  text-shadow: 0 4px 18px rgba(5, 9, 26, 0.75);
 }
 
 .hero__centerpiece {

--- a/src/features/Hero/config.json
+++ b/src/features/Hero/config.json
@@ -1,10 +1,6 @@
 {
   "branding": {
-    "seasonLabel": "Yar Cyber Season 2025/26",
-    "links": [
-      { "label": "Регламент сезона", "href": "/docs/ycs-cup-2025-26.pdf" },
-      { "label": "FAQ", "href": "#faq" }
-    ]
+    "seasonLabel": "Yar Cyber Season 2025/26"
   },
   "title": "YarCyber Season",
   "subtitle": "это киберспортивный проект, который проходит при информационной поддержке Министерства спорта Ярославской области и Федерации компьютерного спорта ЯО.",


### PR DESCRIPTION
## Summary
- remove the hero quicklink buttons for the season regulation and FAQ entries
- restyle the hero subtitle with a glassmorphism panel for better contrast on the light blue background

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffb5ba56fc8323ae4965b03c396b82