### PR TITLE
Remove FAQ link from footer

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -61,10 +61,6 @@ const Footer = ({ isFeminineTheme, onThemeToggle }) => {
             </ul>
           </div>
           <div className="footer__section">
-            <h3 className="footer__section-title">Поддержка</h3>
-            <a className="footer__link" href="#faq">
-              Часто задаваемые вопросы
-            </a>
             <p className="footer__support-note">
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- remove the support header and FAQ link from the footer, leaving only the support note

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffb93ea86c83238c8a50c693b2e2a8