### PR TITLE
fix: show general partner logo correctly

### DIFF
--- a/src/features/Sponsors/config.json
+++ b/src/features/Sponsors/config.json
@@ -41,7 +41,7 @@
       "sponsors": [
         {
           "name": "Cherry RAiT",
-          "logo": "../Hero/logo1.png",
+          "logo": "./logo-cherry.jpg",
           "url": "https://t.me/Talyutin",
           "alt": "Логотип Cherry RAiT"
         }


### PR DESCRIPTION
## Summary
- point the general partner sponsor entry to the correct local logo asset

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ffbf7d32bc8323a34a9314b715bd2e