### PR TITLE
fix: resolve local sponsor logo loading

### DIFF
--- a/src/features/Sponsors/Sponsors.jsx
+++ b/src/features/Sponsors/Sponsors.jsx
@@ -4,6 +4,12 @@ import PropTypes from 'prop-types';
 import SponsorModal from '../../components/SponsorModal/SponsorModal.jsx';
 import './Sponsors.css';
 
+const sponsorLogoAssets = import.meta.glob('./*.{png,jpg,jpeg,gif,svg,webp,avif}', {
+  eager: true,
+  import: 'default',
+  query: '?url',
+});
+
 const resolveSponsorLogo = (logoPath) => {
   if (!logoPath) {
     return '';
@@ -11,6 +17,13 @@ const resolveSponsorLogo = (logoPath) => {
 
   if (/^https?:/i.test(logoPath)) {
     return logoPath;
+  }
+
+  const normalizedPath = logoPath.startsWith('./') ? logoPath : `./${logoPath}`;
+  const localAsset = sponsorLogoAssets[normalizedPath];
+
+  if (localAsset) {
+    return localAsset;
   }
 
   try {

--- a/src/features/Sponsors/config.json
+++ b/src/features/Sponsors/config.json
@@ -41,7 +41,7 @@
       "sponsors": [
         {
           "name": "Cherry RAiT",
-          "logo": "../Hero/logo1.png",
+          "logo": "./logo-cherry.jpg",
           "url": "https://t.me/Talyutin",
           "alt": "Логотип Cherry RAiT"
         }


### PR DESCRIPTION
## Summary
- eagerly import sponsor image assets within the Sponsors feature so local logos resolve to built URLs
- normalize logo paths to match globbed assets before falling back to runtime URL resolution

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ffbf7d32bc8323a34a9314b715bd2e