### PR TITLE
feat: update site header logo to provided asset

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,30 +31,25 @@ main.app {
 .app__logo {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-3);
+  gap: clamp(var(--space-2), 1.5vw, var(--space-3));
   text-decoration: none;
   color: var(--color-text-primary);
 }
 
-.app__logo-mark {
-  display: inline-grid;
-  place-items: center;
-  width: 52px;
-  height: 52px;
+.app__logo-image {
+  display: block;
+  width: clamp(48px, 6vw, 72px);
+  height: auto;
   border-radius: var(--radius-lg);
-  background: var(--gradient-primary);
-  color: #05060f;
-  font-weight: 800;
-  letter-spacing: 0.1em;
-  font-size: 1.4rem;
-  box-shadow: inset 0 0 20px rgba(255, 255, 255, 0.18), 0 10px 26px rgba(139, 123, 255, 0.42);
+  box-shadow: 0 12px 26px rgba(5, 9, 24, 0.45);
 }
 
 .app__logo-text {
-  font-size: 0.9rem;
+  font-size: clamp(0.85rem, 2vw, 1rem);
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--color-text-secondary);
+  font-weight: 600;
 }
 
 .app__nav {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import heroConfig from './features/Hero/config.json';
 import overviewConfig from './features/Overview/config.json';
 import registrationCtaConfig from './features/RegistrationCta/config.json';
 import sponsorsConfig from './features/Sponsors/config.json';
+import logoImage from './ChatGPT Image 20 окт. 2025 г., 22_02_10.png';
 import './App.css';
 
 const App = () => {
@@ -127,10 +128,8 @@ const App = () => {
     <main className="app">
       <header className="app__header">
         <a className="app__logo" href="#hero" aria-label="Перейти к началу страницы">
-          <span className="app__logo-mark" aria-hidden="true">
-            YCS
-          </span>
-          <span className="app__logo-text">YarCyberSeason</span>
+          <img className="app__logo-image" src={logoImage} alt="Логотип YarCyberSeason" />
+          <span className="app__logo-text" aria-hidden="true">YarCyberSeason</span>
         </a>
         <button
           type="button"

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -21,19 +21,26 @@
 .footer__brand {
   display: flex;
   gap: var(--space-3);
-  align-items: flex-start;
+  align-items: center;
 }
 
-.footer__brand-mark {
-  display: inline-grid;
-  place-items: center;
-  width: 56px;
-  height: 56px;
+.footer__brand-logo-wrapper {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-xl);
+  padding: 0.25rem;
+  background: linear-gradient(160deg, rgba(139, 123, 255, 0.65), rgba(64, 232, 194, 0.35));
+  box-shadow: 0 16px 34px rgba(7, 10, 24, 0.45);
+}
+
+.footer__brand-logo {
+  display: block;
+  width: 100%;
+  height: auto;
   border-radius: var(--radius-lg);
-  background: var(--gradient-primary);
-  color: #05060f;
-  font-weight: 700;
-  letter-spacing: 0.12em;
 }
 
 .footer__brand-name {

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
+import logoImage from '../ChatGPT Image 20 окт. 2025 г., 22_02_10.png';
 import './Footer.css';
 
 const Footer = ({ isFeminineTheme, onThemeToggle }) => {
@@ -34,8 +35,12 @@ const Footer = ({ isFeminineTheme, onThemeToggle }) => {
     <footer className="footer" aria-labelledby="footer-title">
       <div className="footer__content">
         <div className="footer__brand" id="footer-title">
-          <span className="footer__brand-mark" aria-hidden="true">
-            YCS
+          <span className="footer__brand-logo-wrapper">
+            <img
+              className="footer__brand-logo"
+              src={logoImage}
+              alt="Логотип YarCyberSeason"
+            />
           </span>
           <div className="footer__brand-text">
             <span className="footer__brand-name">YarCyberSeason</span>


### PR DESCRIPTION
## Summary
- replace the text-only header logo with the provided YarCyberSeason image asset
- tweak logo spacing, sizing, and typography so the new logo renders crisply across breakpoints
- update the footer branding to reuse the YarCyberSeason image asset and align styling with the header

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffc3caa280832399a164472ca16954