### PR TITLE
fix: update qualification CTA link

### DIFF
--- a/src/features/Hero/config.json
+++ b/src/features/Hero/config.json
@@ -16,7 +16,7 @@
       "description": "Подайте  заявку, чтобы попасть в онлайн-квалификацию сезона по Dota 2.",
       "cta": {
         "label": "Заполнить заявку",
-        "href": "/forms/qualification",
+        "href": "https://forms.yandex.ru/u/6831bf5f49363917b3f721e7/",
         "ariaLabel": "Открыть форму регистрации на квалификацию YarCyberSeason",
         "variant": "primary"
       }


### PR DESCRIPTION
## Summary
- update the hero QUAL call-to-action to point to the Yandex form URL

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ffd536268c8323b052fca9b9ba5a58