### PR TITLE
feat: refresh hero background and messaging

### DIFF
--- a/src/features/Hero/Hero.css
+++ b/src/features/Hero/Hero.css
@@ -117,6 +117,15 @@ html[data-theme='feminine'] .hero__overlay {
   text-wrap: pretty;
 }
 
+.hero__description {
+  margin-top: clamp(var(--space-3), 1.8vw, var(--space-4));
+  font-size: clamp(1rem, 0.92rem + 0.5vw, 1.25rem);
+  color: color-mix(in srgb, var(--color-text-primary) 72%, var(--color-text-secondary));
+  line-height: 1.6;
+  max-width: min(64ch, 100%);
+  text-wrap: pretty;
+}
+
 .hero__display-lead {
   font-size: clamp(1.05rem, 0.9rem + 0.8vw, 1.45rem);
   font-weight: 600;

--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import msLogo from './ms.png';
 import fksLogo from './fks.png';
-import heroFeminineBackground from '../../styles/hero-feminine-background.svg';
+import heroBackgroundImage from './image_2025-10-27_20-17-24.png';
 import './Hero.css';
 
 const DEFAULT_EXPIRED_LABEL = 'Сезон уже стартовал';
@@ -85,7 +85,7 @@ const Hero = ({ data }) => {
     },
   ];
 
-  const defaultFallbackImage = heroFeminineBackground;
+  const defaultFallbackImage = heroBackgroundImage;
   const videoSources = Array.isArray(media?.sources) ? media.sources : [];
   const shouldRenderVideo = videoSources.length > 0;
   const fallbackImage = media?.fallbackImage || defaultFallbackImage;
@@ -139,6 +139,10 @@ const Hero = ({ data }) => {
           ) : null}
           <h1 className="hero__title hero__display">{title}</h1>
           <p className="hero__subtitle hero__display-subtitle">{subtitle}</p>
+          <p className="hero__description">
+            это киберспортивный проект, который проходит при официальной поддержке Министерства спорта
+            Ярославской области и Федерации компьютерного спорта (ФКС) ЯО.
+          </p>
 
           {primaryCta || (Array.isArray(branding?.links) && branding.links.length > 0) ? (
             <div className="hero__actions">

--- a/src/features/Hero/config.json
+++ b/src/features/Hero/config.json
@@ -3,24 +3,15 @@
     "tagline": "",
     "label": "  YarCyber 2025/26",
     "seasonLabel": "Yar Cyber Season 2025/26",
-    "links": [
-      {
-        "label": "Программа фестиваля",
-        "href": "#overview"
-      },
-      {
-        "label": "Регистрация",
-        "href": "#registration"
-      }
-    ]
+    "links": []
   },
   "title": "YarCyber Seasonы",
   "subtitle": "",
 
   "media": {
     "disableOnMobile": true,
-    "poster": "/media/hero/feminine-poster.svg",
-    "fallbackImage": "/media/hero/feminine-fallback.svg",
+    "poster": null,
+    "fallbackImage": null,
     "ariaLabel": "Сакуровый фон с золотыми фонарями",
     "sources": []
   },


### PR DESCRIPTION
## Summary
- switch the hero fallback artwork to use the new season illustration
- highlight the official support message within the hero content
- remove redundant quick links from the hero configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ffde519f6c83239937340671a3aae3