### PR TITLE
feat: add upcoming matches section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,8 @@ import RegistrationCta from './features/RegistrationCta/RegistrationCta.jsx';
 import Sponsors from './features/Sponsors/Sponsors.jsx';
 import heroConfig from './features/Hero/config.json';
 import overviewConfig from './features/Overview/config.json';
+import UpcomingMatches from './features/UpcomingMatches/UpcomingMatches.jsx';
+import upcomingMatchesConfig from './features/UpcomingMatches/config.json';
 import registrationCtaConfig from './features/RegistrationCta/config.json';
 import sponsorsConfig from './features/Sponsors/config.json';
 import logoImage from './ChatGPT Image 20 окт. 2025 г., 22_02_10.png';
@@ -41,6 +43,13 @@ const App = () => {
           <div className="overview-background__grain" />
         </div>
       ),
+    },
+    {
+      id: 'upcoming-matches',
+      component: <UpcomingMatches data={upcomingMatchesConfig} />,
+      navLabel: 'Матчи',
+      variant: 'upcoming-matches',
+      hideTitle: true,
     },
     {
       id: 'registration',

--- a/src/features/UpcomingMatches/UpcomingMatches.jsx
+++ b/src/features/UpcomingMatches/UpcomingMatches.jsx
@@ -1,0 +1,92 @@
+import PropTypes from 'prop-types';
+import styles from './UpcomingMatches.module.css';
+
+const UpcomingMatches = ({ data }) => {
+  const { title, tags, matches, channelPresets } = data;
+
+  const resolveChannels = (channelIds) =>
+    channelIds
+      .map((channelId) => channelPresets[channelId])
+      .filter(Boolean);
+
+  return (
+    <section className={styles.upcoming} aria-labelledby="upcoming-matches-title">
+      <header className={styles.header}>
+        <h3 id="upcoming-matches-title" className={styles.title}>
+          {title}
+        </h3>
+        <div className={styles.tags} aria-label="теги турнира">
+          {tags.map((tag) => (
+            <span key={tag} className={styles.tag}>
+              #{tag}
+            </span>
+          ))}
+        </div>
+      </header>
+      <ol className={styles.scheduleList}>
+        {matches.map((match) => {
+          const channels = resolveChannels(match.channelIds);
+
+          return (
+            <li key={match.id} className={styles.matchItem}>
+              <div className={styles.meta}>
+                <span className={styles.dayLabel}>{match.dayLabel}</span>
+                <time className={styles.timeLabel} dateTime={match.dateTime}>
+                  {match.timeLabel}
+                </time>
+              </div>
+              <div className={styles.teams}>
+                <span className={styles.teamName}>{match.teams.home}</span>
+                <span className={styles.separator}>—</span>
+                <span className={styles.teamName}>{match.teams.away}</span>
+              </div>
+              <div className={styles.channels}>
+                {channels.map((channel) => (
+                  <a
+                    key={channel.id}
+                    className={styles.channelLink}
+                    href={channel.url}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                  >
+                    <span className={styles.channelBadge}>{channel.label}</span>
+                    <span>Смотреть</span>
+                  </a>
+                ))}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+};
+
+UpcomingMatches.propTypes = {
+  data: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    tags: PropTypes.arrayOf(PropTypes.string).isRequired,
+    channelPresets: PropTypes.objectOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        url: PropTypes.string.isRequired,
+      }),
+    ).isRequired,
+    matches: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        dayLabel: PropTypes.string.isRequired,
+        timeLabel: PropTypes.string.isRequired,
+        dateTime: PropTypes.string.isRequired,
+        teams: PropTypes.shape({
+          home: PropTypes.string.isRequired,
+          away: PropTypes.string.isRequired,
+        }).isRequired,
+        channelIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+      }),
+    ).isRequired,
+  }).isRequired,
+};
+
+export default UpcomingMatches;

--- a/src/features/UpcomingMatches/UpcomingMatches.module.css
+++ b/src/features/UpcomingMatches/UpcomingMatches.module.css
@@ -1,0 +1,147 @@
+.upcoming {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-4), 2.4vw, var(--space-6));
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: flex-start;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(1.8rem, 1.2rem + 1vw, 2.4rem);
+  font-weight: 700;
+  color: var(--color-text-primary);
+  letter-spacing: -0.01em;
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0.3rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-text-accent);
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 45%, transparent);
+  border-radius: 999px;
+}
+
+.scheduleList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.matchItem {
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.9fr) minmax(0, 1fr) minmax(7rem, auto);
+  align-items: center;
+  gap: var(--space-4);
+  padding: clamp(var(--space-3), 1.5vw, var(--space-4));
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--color-surface) 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
+  box-shadow: 0 12px 28px -24px var(--color-shadow-strong);
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.dayLabel {
+  font-size: 0.9rem;
+}
+
+.timeLabel {
+  font-size: 1.1rem;
+  color: var(--color-text-primary);
+}
+
+.teams {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+  font-size: clamp(1.05rem, 0.9rem + 0.6vw, 1.35rem);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.teamName {
+  white-space: nowrap;
+}
+
+.separator {
+  color: var(--color-text-secondary);
+  opacity: 0.7;
+}
+
+.channels {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.channelLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0.45rem 0.9rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-inverse);
+  background: var(--color-accent);
+  border-radius: 999px;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.channelLink:focus-visible,
+.channelLink:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px -12px color-mix(in srgb, var(--color-accent) 45%, transparent);
+}
+
+.channelBadge {
+  background: rgba(255, 255, 255, 0.15);
+  padding: 0.15rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+@media (max-width: 768px) {
+  .matchItem {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: flex-start;
+  }
+
+  .channels {
+    justify-content: flex-start;
+  }
+}

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -1,0 +1,95 @@
+{
+  "title": "расписание ближайших матчей",
+  "tags": ["dota 2", "qual"],
+  "channelPresets": {
+    "primary": {
+      "id": "primary",
+      "label": "1 канал",
+      "url": "https://www.twitch.tv/yarcyberseason"
+    },
+    "secondary": {
+      "id": "secondary",
+      "label": "2 канал",
+      "url": "https://www.twitch.tv/yarcyberseason2"
+    }
+  },
+  "matches": [
+    {
+      "id": "2025-11-17-mi-ne-pushim-ygk",
+      "dayLabel": "Пнк 17.11",
+      "timeLabel": "19:00",
+      "dateTime": "2025-11-17T19:00:00+03:00",
+      "teams": {
+        "home": "Mi ne Pushim!",
+        "away": "YGK"
+      },
+      "channelIds": ["primary"]
+    },
+    {
+      "id": "2025-11-18-team-borisogleb-ne-znayushchie-pobed",
+      "dayLabel": "Вт 18.11",
+      "timeLabel": "19:00",
+      "dateTime": "2025-11-18T19:00:00+03:00",
+      "teams": {
+        "home": "Team Borisogleb",
+        "away": "Не Знающие Побед"
+      },
+      "channelIds": ["primary"]
+    },
+    {
+      "id": "2025-11-19-japan-blyzhayshie",
+      "dayLabel": "Ср 19.11",
+      "timeLabel": "19:00",
+      "dateTime": "2025-11-19T19:00:00+03:00",
+      "teams": {
+        "home": "Japan 日本",
+        "away": "Ближайшие"
+      },
+      "channelIds": ["secondary"]
+    },
+    {
+      "id": "2025-11-19-geeks-way-prod",
+      "dayLabel": "Ср 19.11",
+      "timeLabel": "19:00",
+      "dateTime": "2025-11-19T19:00:00+03:00",
+      "teams": {
+        "home": "Гики",
+        "away": "Way prod."
+      },
+      "channelIds": ["primary"]
+    },
+    {
+      "id": "2025-11-20-yellow-submarine-arb-esports",
+      "dayLabel": "Чт 20.11",
+      "timeLabel": "19:00",
+      "dateTime": "2025-11-20T19:00:00+03:00",
+      "teams": {
+        "home": "Yellow Submarine",
+        "away": "ARB esports"
+      },
+      "channelIds": ["primary"]
+    },
+    {
+      "id": "2025-11-21-steel-titans-labubu-team",
+      "dayLabel": "Пт 21.11",
+      "timeLabel": "19:00",
+      "dateTime": "2025-11-21T19:00:00+03:00",
+      "teams": {
+        "home": "Steel Titans",
+        "away": "Labubu team"
+      },
+      "channelIds": ["primary"]
+    },
+    {
+      "id": "2025-11-23-buyback-academy-tech-titans",
+      "dayLabel": "Вск 23.11",
+      "timeLabel": "15:00",
+      "dateTime": "2025-11-23T15:00:00+03:00",
+      "teams": {
+        "home": "Buyback Academy",
+        "away": "Tech Titans"
+      },
+      "channelIds": ["primary"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add an UpcomingMatches feature that renders the qualifier schedule with channel links and modular styling
- capture match data and stream presets in configuration to support single- and multi-channel broadcasts
- register the new section in the application navigation for consistent access

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170b316e388323aee5548859e94493)