### PR TITLE
Refactor team showcase config loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.2",
         "prettier": "^3.3.2",
+        "react-test-renderer": "^18.3.1",
         "vite": "^5.2.0"
       }
     },
@@ -3960,6 +3961,42 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+      "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.3.1",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-test-renderer/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.2",
     "prettier": "^3.3.2",
+    "react-test-renderer": "^18.3.1",
     "vite": "^5.2.0"
   }
 }

--- a/src/features/team-showcase/TeamShowcase.js
+++ b/src/features/team-showcase/TeamShowcase.js
@@ -2,17 +2,27 @@ import {
   createElement,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
 
-import data from './loadConfig.js';
+import { getCachedConfig, loadConfig } from './loadConfig.js';
 import { getFollowingIndex, getNextIndex, getPreviousIndex } from './carouselUtils.js';
 
-if (typeof document !== 'undefined') {
-  await import('./TeamShowcase.css');
-}
+export const loadTeamShowcaseStyles = (loader = () => import('./TeamShowcase.css')) => {
+  if (typeof document === 'undefined') {
+    return Promise.resolve(false);
+  }
+
+  return loader()
+    .then(() => true)
+    .catch((error) => {
+      if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+        console.error('Failed to load TeamShowcase styles', error);
+      }
+      return false;
+    });
+};
 
 const AUTO_PLAY_INTERVAL = 8000;
 const numberFormatter = new Intl.NumberFormat('ru-RU');
@@ -71,11 +81,35 @@ const renderTeamSlide = (team, index, activeIndex) =>
   );
 
 const TeamShowcase = () => {
-  const teams = useMemo(() => data, []);
+  const [teams, setTeams] = useState(() => getCachedConfig() ?? []);
   const [activeIndex, setActiveIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
   const totalSlides = teams.length;
   const autoplayRef = useRef(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    loadConfig()
+      .then((dataset) => {
+        if (isMounted) {
+          setTeams(dataset);
+        }
+      })
+      .catch((error) => {
+        if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+          console.error('Failed to load TeamShowcase config', error);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    loadTeamShowcaseStyles();
+  }, []);
 
   const goToIndex = useCallback(
     (index) => {
@@ -98,7 +132,7 @@ const TeamShowcase = () => {
   }, [totalSlides]);
 
   useEffect(() => {
-    if (totalSlides <= 1 || isPaused) {
+    if (typeof document === 'undefined' || totalSlides <= 1 || isPaused) {
       return undefined;
     }
 

--- a/src/features/team-showcase/TeamShowcase.js
+++ b/src/features/team-showcase/TeamShowcase.js
@@ -17,7 +17,10 @@ export const loadTeamShowcaseStyles = (loader = () => import('./TeamShowcase.css
   return loader()
     .then(() => true)
     .catch((error) => {
-      if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+      if (
+        typeof globalThis !== 'undefined' &&
+        globalThis.process?.env?.NODE_ENV !== 'production'
+      ) {
         console.error('Failed to load TeamShowcase styles', error);
       }
       return false;
@@ -97,7 +100,10 @@ const TeamShowcase = () => {
         }
       })
       .catch((error) => {
-        if (typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production') {
+        if (
+          typeof globalThis !== 'undefined' &&
+          globalThis.process?.env?.NODE_ENV !== 'production'
+        ) {
           console.error('Failed to load TeamShowcase config', error);
         }
       });

--- a/src/features/team-showcase/TeamShowcase.test.js
+++ b/src/features/team-showcase/TeamShowcase.test.js
@@ -2,15 +2,51 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { renderToStaticMarkup } from 'react-dom/server';
 import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
 
-import TeamShowcase from './TeamShowcase.js';
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const data = require('./config.json');
+import TeamShowcase, { loadTeamShowcaseStyles } from './TeamShowcase.js';
+import {
+  clearConfigCache,
+  getCachedConfig,
+  loadConfig,
+} from './loadConfig.js';
 import { getFollowingIndex, getNextIndex, getPreviousIndex } from './carouselUtils.js';
 
-test('TeamShowcase renders all teams inside the carousel track', () => {
+const countByClassName = (node, className) => {
+  if (!node) {
+    return 0;
+  }
+
+  if (Array.isArray(node)) {
+    return node.reduce((acc, child) => acc + countByClassName(child, className), 0);
+  }
+
+  if (typeof node === 'string') {
+    return 0;
+  }
+
+  const nodeClassName = node.props?.className ?? '';
+  const ownMatch = nodeClassName.split(' ').includes(className) ? 1 : 0;
+  const children = node.children ?? [];
+
+  return ownMatch + countByClassName(children, className);
+};
+
+test('loadConfig resolves dataset and caches the result', async () => {
+  clearConfigCache();
+
+  const dataset = await loadConfig();
+  assert.ok(Array.isArray(dataset), 'конфиг должен быть массивом команд');
+  assert.equal(getCachedConfig(), dataset, 'должен заполняться кеш');
+
+  const secondCall = await loadConfig();
+  assert.equal(secondCall, dataset, 'повторные вызовы возвращают кешированные данные');
+});
+
+test('TeamShowcase renders all teams inside the carousel track after preloading', async () => {
+  await loadConfig();
+  const data = getCachedConfig();
+
   const markup = renderToStaticMarkup(React.createElement(TeamShowcase));
 
   const slideCount = (markup.match(/team-showcase__slide/g) || []).length;
@@ -25,6 +61,47 @@ test('TeamShowcase renders all teams inside the carousel track', () => {
       `Команда ${team.name} должна отображаться в разметке`,
     );
   }
+});
+
+test('TeamShowcase loads config asynchronously when cache is empty', async () => {
+  clearConfigCache();
+
+  let renderer;
+  await act(async () => {
+    renderer = TestRenderer.create(React.createElement(TeamShowcase));
+  });
+
+  await act(async () => {
+    await loadConfig();
+  });
+
+  const tree = renderer.toJSON();
+  const resolvedSlideCount = countByClassName(tree, 'team-showcase__slide');
+  assert.ok(
+    resolvedSlideCount >= (getCachedConfig()?.length ?? 0),
+    'после загрузки конфигурации количество слайдов соответствует данным',
+  );
+
+  await act(async () => {
+    renderer.unmount();
+  });
+});
+
+test('loadTeamShowcaseStyles resolves only in browser-like environments', async () => {
+  delete globalThis.document;
+  const serverResult = await loadTeamShowcaseStyles();
+  assert.equal(serverResult, false, 'на сервере загрузка стилей пропускается');
+
+  const loaderCalls = [];
+  globalThis.document = {};
+  const browserResult = await loadTeamShowcaseStyles(() => {
+    loaderCalls.push(true);
+    return Promise.resolve();
+  });
+  assert.equal(browserResult, true, 'в браузере стили загружаются');
+  assert.equal(loaderCalls.length, 1, 'используется предоставленный загрузчик стилей');
+
+  delete globalThis.document;
 });
 
 test('carousel utils correctly calculate next indices', () => {

--- a/src/features/team-showcase/loadConfig.js
+++ b/src/features/team-showcase/loadConfig.js
@@ -1,12 +1,40 @@
-let dataset;
+let cachedDataset;
+let loadingPromise;
 
-if (typeof document === 'undefined') {
-  const { createRequire } = await import('node:module');
-  const require = createRequire(import.meta.url);
-  dataset = require('./config.json');
-} else {
-  const module = await import('./config.json');
-  dataset = module.default ?? module;
+export const getCachedConfig = () => cachedDataset ?? null;
+
+export const clearConfigCache = () => {
+  cachedDataset = undefined;
+  loadingPromise = undefined;
+};
+
+export async function loadConfig() {
+  if (cachedDataset) {
+    return cachedDataset;
+  }
+
+  if (!loadingPromise) {
+    loadingPromise = (async () => {
+      try {
+        let dataset;
+        if (typeof document === 'undefined') {
+          const { createRequire } = await import('node:module');
+          const require = createRequire(import.meta.url);
+          dataset = require('./config.json');
+        } else {
+          const module = await import('./config.json');
+          dataset = module.default ?? module;
+        }
+
+        cachedDataset = dataset;
+        return dataset;
+      } catch (error) {
+        cachedDataset = undefined;
+        loadingPromise = undefined;
+        throw error;
+      }
+    })();
+  }
+
+  return loadingPromise;
 }
-
-export default dataset;


### PR DESCRIPTION
## Summary
- replace the team showcase config module with an async loader that caches results for node and browser environments
- update the TeamShowcase component to hydrate data via the new loader, lazy-load styles in the browser, and guard autoplay for SSR
- extend tests to cover asynchronous config/style loading and add react-test-renderer for the new assertions

## Testing
- npm test
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177e27b5a483238fee35e3f0d343ce)