### PR TITLE
fix: tighten social link cards layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,12 +7,14 @@ import Overview from './features/Overview/Overview.jsx';
 import RegistrationCta from './features/RegistrationCta/RegistrationCta.jsx';
 import Sponsors from './features/Sponsors/Sponsors.jsx';
 import TeamShowcase from './features/team-showcase/TeamShowcase.js';
+import SocialLinks from './features/SocialLinks/SocialLinks.jsx';
 import heroConfig from './features/Hero/config.json';
 import overviewConfig from './features/Overview/config.json';
 import UpcomingMatches from './features/UpcomingMatches/UpcomingMatches.jsx';
 import upcomingMatchesConfig from './features/UpcomingMatches/config.json';
 import registrationCtaConfig from './features/RegistrationCta/config.json';
 import sponsorsConfig from './features/Sponsors/config.json';
+import socialLinksConfig from './features/SocialLinks/config.json';
 import logoImage from './ChatGPT Image 20 окт. 2025 г., 22_02_10.png';
 import './App.css';
 
@@ -65,6 +67,14 @@ const App = () => {
       component: <RegistrationCta data={registrationCtaConfig} />,
       navLabel: 'Регистрация',
       variant: 'registration-cta',
+      hideTitle: true,
+    },
+    {
+      id: 'social',
+      title: 'Социальные каналы',
+      component: <SocialLinks data={socialLinksConfig} />,
+      navLabel: 'Соцсети',
+      variant: 'social-links',
       hideTitle: true,
     },
     {

--- a/src/features/SocialLinks/SocialLinks.css
+++ b/src/features/SocialLinks/SocialLinks.css
@@ -1,0 +1,197 @@
+.social-links {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: clamp(var(--space-4), 4vw, var(--space-6));
+  border-radius: var(--radius-xl);
+  background: color-mix(in srgb, var(--color-surface) 75%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 85%, transparent);
+  box-shadow: var(--shadow-soft);
+}
+
+.social-links__intro {
+  max-width: 640px;
+}
+
+.social-links__eyebrow {
+  margin: 0 0 var(--space-2);
+  font-size: 0.85rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+}
+
+.social-links__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 2.2rem);
+  line-height: 1.2;
+}
+
+.social-links__description {
+  margin: var(--space-2) 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.95rem;
+}
+
+.social-links__panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-4);
+}
+
+.social-links__panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  background: var(--color-card);
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+
+[data-theme='feminine'] .social-links__panel {
+  background: var(--color-card);
+}
+
+.social-links__panel-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.social-links__panel-eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.social-links__panel-title {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.social-links__panel-description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.social-links__list {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.social-links__list--streams {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.social-links__list--community {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.social-links__card {
+  --social-accent: var(--color-primary);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  width: 100%;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
+  background: color-mix(in srgb, var(--color-surface) 85%, transparent);
+  text-decoration: none;
+  color: var(--color-text-primary);
+  transition: border-color var(--transition-fast), transform var(--transition-fast);
+}
+
+.social-links__card:hover,
+.social-links__card:focus-visible {
+  border-color: var(--social-accent);
+  transform: translateY(-2px);
+}
+
+.social-links__card-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--social-accent) 12%, transparent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.social-links__card-icon img {
+  width: 24px;
+  height: 24px;
+}
+
+.social-links__card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+  flex: 1 1 200px;
+}
+
+.social-links__card-label {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.social-links__card-handle {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.social-links__card-description {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.social-links__card-action {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--social-accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  margin-left: auto;
+  min-width: max-content;
+}
+
+.social-links__card--youtube {
+  --social-accent: var(--color-danger);
+}
+
+.social-links__card--email {
+  --social-accent: var(--color-secondary);
+}
+
+.social-links__card--tiktok {
+  --social-accent: var(--color-secondary);
+}
+
+.social-links__card--instagram {
+  --social-accent: var(--color-tertiary);
+}
+
+.social-links__footnote {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 640px) {
+  .social-links__card-action {
+    width: 100%;
+    justify-content: center;
+    margin-left: 0;
+  }
+}

--- a/src/features/SocialLinks/SocialLinks.jsx
+++ b/src/features/SocialLinks/SocialLinks.jsx
@@ -1,0 +1,118 @@
+import PropTypes from 'prop-types';
+import './SocialLinks.css';
+
+import twitchIcon from './icons/icon-twitch.svg';
+import youtubeIcon from './icons/icon-youtube.svg';
+import emailIcon from './icons/icon-email.svg';
+import tiktokIcon from './icons/icon-tiktok.svg';
+import instagramIcon from './icons/icon-instagram.svg';
+
+const iconMap = {
+  twitch: twitchIcon,
+  youtube: youtubeIcon,
+  email: emailIcon,
+  tiktok: tiktokIcon,
+  instagram: instagramIcon,
+};
+
+const getTarget = (url) => (url.startsWith('mailto:') ? undefined : '_blank');
+const getRel = (url) => (url.startsWith('mailto:') ? undefined : 'noreferrer');
+
+const SocialLinks = ({ data }) => {
+  const { eyebrow, title, description, channels = [], footnote } = data || {};
+  const twitchChannels = channels.filter((channel) => channel.type === 'twitch');
+  const communityChannels = channels.filter((channel) => channel.type !== 'twitch');
+
+  const renderChannelCard = (channel) => {
+    const { id, label, handle, description: channelDescription, url, type } = channel;
+    const iconSrc = iconMap[type] || iconMap.email;
+    const actionText = type === 'twitch' ? 'Смотреть' : 'Открыть';
+
+    return (
+      <a
+        key={id}
+        className={`social-links__card social-links__card--${type}`}
+        href={url}
+        target={getTarget(url)}
+        rel={getRel(url)}
+        aria-label={`${label} — ${handle}`}
+      >
+        <span className="social-links__card-icon" aria-hidden="true">
+          <img src={iconSrc} alt="" loading="lazy" />
+        </span>
+        <span className="social-links__card-body">
+          <span className="social-links__card-label">{label}</span>
+          <span className="social-links__card-handle">{handle}</span>
+          {channelDescription ? (
+            <span className="social-links__card-description">{channelDescription}</span>
+          ) : null}
+        </span>
+        <span className="social-links__card-action" aria-hidden="true">
+          {actionText}
+        </span>
+      </a>
+    );
+  };
+
+  return (
+    <section className="social-links" aria-label="Социальные каналы YarCyberSeason">
+      <div className="social-links__intro">
+        {eyebrow ? <p className="social-links__eyebrow">{eyebrow}</p> : null}
+        {title ? <h3 className="social-links__title">{title}</h3> : null}
+        {description ? <p className="social-links__description">{description}</p> : null}
+      </div>
+      <div className="social-links__panels">
+        {twitchChannels.length ? (
+          <div className="social-links__panel social-links__panel--streams">
+            <div className="social-links__panel-head">
+              <p className="social-links__panel-eyebrow">Прямые эфиры</p>
+              <h4 className="social-links__panel-title">Трансляции и аналитика</h4>
+              <p className="social-links__panel-description">
+                Три Twitch-канала для основного эфира, аналитики и тренировок.
+              </p>
+            </div>
+            <div className="social-links__list social-links__list--streams">
+              {twitchChannels.map(renderChannelCard)}
+            </div>
+          </div>
+        ) : null}
+        {communityChannels.length ? (
+          <div className="social-links__panel social-links__panel--community">
+            <div className="social-links__panel-head">
+              <p className="social-links__panel-eyebrow">Комьюнити</p>
+              <h4 className="social-links__panel-title">Соцсети и связь</h4>
+              <p className="social-links__panel-description">
+                Контент для TikTok и Instagram, YouTube-хайлайты и почта для партнёров.
+              </p>
+            </div>
+            <div className="social-links__list social-links__list--community">
+              {communityChannels.map(renderChannelCard)}
+            </div>
+          </div>
+        ) : null}
+      </div>
+      {footnote ? <p className="social-links__footnote">{footnote}</p> : null}
+    </section>
+  );
+};
+
+SocialLinks.propTypes = {
+  data: PropTypes.shape({
+    eyebrow: PropTypes.string,
+    title: PropTypes.string,
+    description: PropTypes.string,
+    footnote: PropTypes.string,
+    channels: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        handle: PropTypes.string,
+        description: PropTypes.string,
+        url: PropTypes.string.isRequired,
+        type: PropTypes.oneOf(['twitch', 'youtube', 'email', 'tiktok', 'instagram']).isRequired,
+      })
+    ),
+  }).isRequired,
+};
+
+export default SocialLinks;

--- a/src/features/SocialLinks/config.json
+++ b/src/features/SocialLinks/config.json
@@ -1,0 +1,64 @@
+{
+  "eyebrow": "Сообщество",
+  "title": "Всегда на связи с YarCyberSeason",
+  "description": "Подключайтесь к трансляциям, следите за закулисьем и ловите анонсы турниров на любимых платформах. Мы публикуем расписание, хайлайты и backstage-контент — выбирайте удобный канал и будьте в курсе сезона.",
+  "channels": [
+    {
+      "id": "twitch-main",
+      "label": "Twitch #1",
+      "handle": "@yarcyberseason",
+      "description": "Главная арена с прямыми трансляциями матчей и плей-офф.",
+      "url": "https://www.twitch.tv/yarcyberseason",
+      "type": "twitch"
+    },
+    {
+      "id": "twitch-analytics",
+      "label": "Twitch #2",
+      "handle": "@yarcyberseason2",
+      "description": "За кадром: аналитика, интервью и дружеские шоу-матчи.",
+      "url": "https://www.twitch.tv/yarcyberseason2",
+      "type": "twitch"
+    },
+    {
+      "id": "twitch-community",
+      "label": "Twitch #3",
+      "handle": "@yarcyberseason3",
+      "description": "Комьюнити-стримы и тренировочные сессии команд.",
+      "url": "https://www.twitch.tv/yarcyberseason3",
+      "type": "twitch"
+    },
+    {
+      "id": "youtube",
+      "label": "YouTube",
+      "handle": "@YarCyberSeason",
+      "description": "Хайлайты, обзоры патчей и документалка о пути участников.",
+      "url": "https://www.youtube.com/@YarCyberSeason",
+      "type": "youtube"
+    },
+    {
+      "id": "email",
+      "label": "Email",
+      "handle": "yarcyberseason@gmail.com",
+      "description": "Вопросы по партнёрству и орг. моменты? Пишите напрямую.",
+      "url": "mailto:yarcyberseason@gmail.com",
+      "type": "email"
+    },
+    {
+      "id": "tiktok",
+      "label": "TikTok",
+      "handle": "@yarcyberseason",
+      "description": "Быстрые нарезки, тренды и backstage-лифты настроения.",
+      "url": "https://www.tiktok.com/@yarcyberseason",
+      "type": "tiktok"
+    },
+    {
+      "id": "instagram",
+      "label": "Instagram",
+      "handle": "@yarcyberseason",
+      "description": "Фото-дайджесты матчей и живое общение со зрителями.",
+      "url": "https://www.instagram.com/yarcyberseason/",
+      "type": "instagram"
+    }
+  ],
+  "footnote": "Навигация обновляется автоматически — добавим новые площадки по мере расширения YarCyberSeason."
+}

--- a/src/features/SocialLinks/icons/icon-email.svg
+++ b/src/features/SocialLinks/icons/icon-email.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="7" width="24" height="18" rx="4" fill="#40e8c2"/>
+  <path d="M6 10l10 7 10-7" stroke="#05231b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/features/SocialLinks/icons/icon-instagram.svg
+++ b/src/features/SocialLinks/icons/icon-instagram.svg
@@ -1,0 +1,11 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="5" width="22" height="22" rx="6" fill="url(#grad)"/>
+  <circle cx="16" cy="16" r="5" stroke="#fff" stroke-width="2" fill="none"/>
+  <circle cx="22.5" cy="9.5" r="1.5" fill="#fff"/>
+  <defs>
+    <linearGradient id="grad" x1="5" y1="5" x2="27" y2="27" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#ff6fcf"/>
+      <stop offset="1" stop-color="#f2c972"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/features/SocialLinks/icons/icon-tiktok.svg
+++ b/src/features/SocialLinks/icons/icon-tiktok.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="16" cy="16" r="13" fill="#0d1d21" stroke="#2ef2d2" stroke-width="2"/>
+  <path d="M18.5 9c0 3 2.5 4 4 4v3.2c-1.8 0-3.3-.6-4.7-1.7v5.3a5 5 0 01-5 5h-.8a4 4 0 01-4-4c0-2.6 2-4.8 4.6-4.8.4 0 .8.05 1.2.15V9h3.7z" fill="#2ef2d2"/>
+</svg>

--- a/src/features/SocialLinks/icons/icon-twitch.svg
+++ b/src/features/SocialLinks/icons/icon-twitch.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="5" width="26" height="22" rx="4" ry="4" fill="#8b7bff"/>
+  <path d="M9 9h14v9.5L18 23h-4l-3 2v-2H9V9z" fill="#1b102e"/>
+  <path d="M18 12v6" stroke="#f8f9ff" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M13 12v6" stroke="#f8f9ff" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/src/features/SocialLinks/icons/icon-youtube.svg
+++ b/src/features/SocialLinks/icons/icon-youtube.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="2" y="8" width="28" height="16" rx="8" fill="#ff4d67"/>
+  <path d="M14 12l7 4-7 4v-8z" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- switch the SocialLinks cards to a flexible layout with wrapping so their CTAs stay contained inside the panels
- restyle the action pill and icon container to keep spacing consistent on narrow breakpoints

## Testing
- npm run lint
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b2deeff648323a7fccfce64ffa158)