### PR TITLE
fix: update match sections copy

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,8 @@ import heroConfig from './features/Hero/config.json';
 import overviewConfig from './features/Overview/config.json';
 import UpcomingMatches from './features/UpcomingMatches/UpcomingMatches.jsx';
 import upcomingMatchesConfig from './features/UpcomingMatches/config.json';
+import MatchResults from './features/MatchResults/MatchResults.jsx';
+import matchResultsConfig from './features/MatchResults/config.json';
 import registrationCtaConfig from './features/RegistrationCta/config.json';
 import sponsorsConfig from './features/Sponsors/config.json';
 import socialLinksConfig from './features/SocialLinks/config.json';
@@ -60,6 +62,13 @@ const App = () => {
       component: <UpcomingMatches data={upcomingMatchesConfig} />,
       navLabel: 'Матчи',
       variant: 'upcoming-matches',
+      hideTitle: true,
+    },
+    {
+      id: 'match-results',
+      component: <MatchResults data={matchResultsConfig} />,
+      navLabel: 'Результаты',
+      variant: 'match-results',
       hideTitle: true,
     },
     {

--- a/src/features/MatchResults/MatchResults.jsx
+++ b/src/features/MatchResults/MatchResults.jsx
@@ -1,0 +1,106 @@
+import PropTypes from 'prop-types';
+import styles from './MatchResults.module.css';
+
+const MatchResults = ({ data }) => {
+  const { title, description, matches } = data;
+
+  const buildScoreLabel = (match) =>
+    `${match.teams.home} ${match.score.home} — ${match.score.away} ${match.teams.away} · BO${match.bestOf}`;
+
+  return (
+    <section className={styles.results} aria-labelledby="match-results-title">
+      <header className={styles.header}>
+        <div>
+          <h3 id="match-results-title" className={styles.title}>
+            {title}
+          </h3>
+          {description ? (
+            <p className={styles.description}>{description}</p>
+          ) : null}
+        </div>
+      </header>
+      <ol className={styles.resultsList} aria-label="Список последних матчей">
+        {matches.map((match) => {
+          const scoreLabel = buildScoreLabel(match);
+          const isHomeWinner = match.winner === 'home';
+          const isAwayWinner = match.winner === 'away';
+
+          return (
+            <li key={match.id} className={styles.resultItem}>
+              <div className={styles.meta}>
+                <time dateTime={match.dateTime} className={styles.date}>
+                  {match.dateLabel}
+                </time>
+                {match.stage ? (
+                  <span className={styles.stage}>{match.stage}</span>
+                ) : null}
+              </div>
+              <div className={styles.teams}>
+                <div className={`${styles.team} ${isHomeWinner ? styles.teamWinner : ''}`}>
+                  <span className={styles.teamName}>{match.teams.home}</span>
+                </div>
+                <div className={styles.scoreWrapper} aria-label={`Счёт: ${scoreLabel}`}>
+                  <span className={styles.score} aria-hidden="true">
+                    <span className={styles.scoreValue}>{match.score.home}</span>
+                    <span className={styles.scoreSeparator}>—</span>
+                    <span className={styles.scoreValue}>{match.score.away}</span>
+                  </span>
+                  <span className={styles.bestOf} aria-label={`Формат серии best-of-${match.bestOf}`}>
+                    BO{match.bestOf}
+                  </span>
+                </div>
+                <div className={`${styles.team} ${isAwayWinner ? styles.teamWinner : ''}`}>
+                  <span className={styles.teamName}>{match.teams.away}</span>
+                </div>
+              </div>
+              <div className={styles.statusWrapper}>
+                <span className={styles.status} data-status={match.status}>
+                  {match.statusLabel}
+                </span>
+                <a
+                  className={styles.detailsLink}
+                  href={match.detailsUrl}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  {match.detailsLabel}
+                </a>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+};
+
+MatchResults.propTypes = {
+  data: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    matches: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        dateLabel: PropTypes.string.isRequired,
+        dateTime: PropTypes.string.isRequired,
+        stage: PropTypes.string,
+        teams: PropTypes.shape({
+          home: PropTypes.string.isRequired,
+          away: PropTypes.string.isRequired,
+        }).isRequired,
+        score: PropTypes.shape({
+          home: PropTypes.number.isRequired,
+          away: PropTypes.number.isRequired,
+        }).isRequired,
+        bestOf: PropTypes.number.isRequired,
+        status: PropTypes.string.isRequired,
+        statusLabel: PropTypes.string.isRequired,
+        detailsUrl: PropTypes.string.isRequired,
+        detailsLabel: PropTypes.string.isRequired,
+        winner: PropTypes.oneOf(['home', 'away']).isRequired,
+      }),
+    ).isRequired,
+  }).isRequired,
+};
+
+export default MatchResults;

--- a/src/features/MatchResults/MatchResults.module.css
+++ b/src/features/MatchResults/MatchResults.module.css
@@ -1,0 +1,180 @@
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-4), 2vw, var(--space-5));
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(1.8rem, 1.2rem + 1vw, 2.4rem);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.description {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 1rem;
+}
+
+.resultsList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.resultItem {
+  display: grid;
+  grid-template-columns: minmax(8rem, 0.9fr) minmax(0, 1.3fr) minmax(8rem, 0.8fr);
+  gap: clamp(var(--space-3), 1.6vw, var(--space-5));
+  padding: clamp(var(--space-3), 1.5vw, var(--space-4));
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
+  box-shadow: 0 18px 36px -28px var(--color-shadow-strong);
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.date {
+  font-size: 0.9rem;
+  color: var(--color-text-primary);
+  font-weight: 700;
+}
+
+.stage {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.teams {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  gap: clamp(var(--space-2), 1vw, var(--space-3));
+}
+
+.team {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.team:nth-child(3) {
+  justify-content: flex-end;
+}
+
+.teamName {
+  font-size: clamp(1rem, 0.9rem + 0.4vw, 1.25rem);
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.teamWinner .teamName {
+  color: var(--color-accent-strong, var(--color-accent));
+  text-shadow: 0 0 16px color-mix(in srgb, var(--color-accent) 40%, transparent);
+}
+
+.scoreWrapper {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-surface) 50%, rgba(255, 255, 255, 0.08));
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+
+.score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-1);
+  font-size: clamp(1.4rem, 1rem + 1vw, 1.8rem);
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.scoreValue {
+  min-width: 1ch;
+  text-align: center;
+}
+
+.scoreSeparator {
+  opacity: 0.7;
+}
+
+.bestOf {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.statusWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-2);
+}
+
+.status {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.status[data-status='finished'] {
+  color: var(--color-text-success, #8ce99a);
+}
+
+.detailsLink {
+  align-self: flex-end;
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--color-text-inverse);
+  background: var(--color-accent);
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.detailsLink:hover,
+.detailsLink:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px -16px color-mix(in srgb, var(--color-accent) 55%, transparent);
+}
+
+@media (max-width: 960px) {
+  .resultItem {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .teams {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .team,
+  .team:nth-child(3) {
+    justify-content: center;
+  }
+
+  .statusWrapper {
+    align-items: flex-start;
+  }
+}

--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -1,0 +1,26 @@
+{
+  "title": "Результаты последних матчей",
+  "description": "Следите за динамикой плей-офф: счёт, формат серии и быстрые ссылки на повторы.",
+  "matches": [
+    {
+      "id": "2025-11-17-qual-mi-ne-pushim-ygk",
+      "dateLabel": "17 ноя · 19:00",
+      "dateTime": "2025-11-17T19:00:00+03:00",
+      "stage": "Квалификация · Раунд 1",
+      "teams": {
+        "home": "Mi ne Pushim!",
+        "away": "YGK"
+      },
+      "score": {
+        "home": 2,
+        "away": 0
+      },
+      "bestOf": 3,
+      "status": "finished",
+      "statusLabel": "2–0 · завершён",
+      "detailsUrl": "https://www.youtube.com/watch?v=qual-mi-ne-pushim-ygk",
+      "detailsLabel": "Смотреть повтор",
+      "winner": "home"
+    }
+  ]
+}

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -1,5 +1,5 @@
 {
-  "title": "расписание ближайших матчей",
+  "title": "Расписание ближайших матчей",
   "tags": ["dota 2", "qual"],
   "channelPresets": {
     "primary": {
@@ -19,17 +19,6 @@
     }
   },
   "matches": [
-    {
-      "id": "2025-11-17-mi-ne-pushim-ygk",
-      "dayLabel": "Пнк 17.11",
-      "timeLabel": "19:00",
-      "dateTime": "2025-11-17T19:00:00+03:00",
-      "teams": {
-        "home": "Mi ne Pushim!",
-        "away": "YGK"
-      },
-      "channelIds": ["secondary"]
-    },
     {
       "id": "2025-11-18-team-borisogleb-ne-znayushchie-pobed",
       "dayLabel": "Ср 19.11",
@@ -54,9 +43,9 @@
     },
     {
       "id": "2025-11-19-geeks-way-prod",
-      "dayLabel": "Ср 19.11",
+      "dayLabel": "Пт 21.11",
       "timeLabel": "19:00",
-      "dateTime": "2025-11-19T19:00:00+03:00",
+      "dateTime": "2025-11-21T19:00:00+03:00",
       "teams": {
         "home": "Гики",
         "away": "Way prod."


### PR DESCRIPTION
## Summary
- capitalize the titles for the upcoming matches and recent results blocks to follow the requested casing
- move the Geeks vs Way prod. qualifier series in the upcoming schedule to Friday 21.11 at 19:00 so the displayed date matches the current plan

## Testing
- npm run lint
- npm test -- --watch=false

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8ab5ba80832397fdd4cf06526bad)