### PR TITLE
chore: relabel map scores as games

### DIFF
--- a/src/features/MatchResults/MatchResults.jsx
+++ b/src/features/MatchResults/MatchResults.jsx
@@ -1,11 +1,29 @@
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import styles from './MatchResults.module.css';
 
 const MatchResults = ({ data }) => {
-  const { title, description, matches } = data;
+  const { title, description, rounds } = data;
+
+  const [expandedRounds, setExpandedRounds] = useState(() =>
+    rounds.reduce(
+      (acc, round) => ({
+        ...acc,
+        [round.id]: Boolean(round.defaultExpanded),
+      }),
+      {},
+    ),
+  );
 
   const buildScoreLabel = (match) =>
     `${match.teams.home} ${match.score.home} — ${match.score.away} ${match.teams.away} · BO${match.bestOf}`;
+
+  const toggleRound = (roundId) => {
+    setExpandedRounds((prev) => ({
+      ...prev,
+      [roundId]: !prev[roundId],
+    }));
+  };
 
   return (
     <section className={styles.results} aria-labelledby="match-results-title">
@@ -14,90 +32,190 @@ const MatchResults = ({ data }) => {
           <h3 id="match-results-title" className={styles.title}>
             {title}
           </h3>
-          {description ? (
-            <p className={styles.description}>{description}</p>
-          ) : null}
+          {description ? <p className={styles.description}>{description}</p> : null}
         </div>
       </header>
-      <ol className={styles.resultsList} aria-label="Список последних матчей">
-        {matches.map((match) => {
-          const scoreLabel = buildScoreLabel(match);
-          const isHomeWinner = match.winner === 'home';
-          const isAwayWinner = match.winner === 'away';
+
+      <div className={styles.rounds}>
+        {rounds.map((round) => {
+          const isExpanded = expandedRounds[round.id];
+          const panelId = `round-panel-${round.id}`;
+          const buttonId = `round-toggle-${round.id}`;
 
           return (
-            <li key={match.id} className={styles.resultItem}>
-              <div className={styles.meta}>
-                <time dateTime={match.dateTime} className={styles.date}>
-                  {match.dateLabel}
-                </time>
-                {match.stage ? (
-                  <span className={styles.stage}>{match.stage}</span>
-                ) : null}
-              </div>
-              <div className={styles.teams}>
-                <div className={`${styles.team} ${isHomeWinner ? styles.teamWinner : ''}`}>
-                  <span className={styles.teamName}>{match.teams.home}</span>
-                </div>
-                <div className={styles.scoreWrapper} aria-label={`Счёт: ${scoreLabel}`}>
-                  <span className={styles.score} aria-hidden="true">
-                    <span className={styles.scoreValue}>{match.score.home}</span>
-                    <span className={styles.scoreSeparator}>—</span>
-                    <span className={styles.scoreValue}>{match.score.away}</span>
-                  </span>
-                  <span className={styles.bestOf} aria-label={`Формат серии best-of-${match.bestOf}`}>
-                    BO{match.bestOf}
-                  </span>
-                </div>
-                <div className={`${styles.team} ${isAwayWinner ? styles.teamWinner : ''}`}>
-                  <span className={styles.teamName}>{match.teams.away}</span>
+            <article key={round.id} className={styles.round}>
+              <div className={styles.roundHeader}>
+                <div className={styles.roundMetaWrapper}>
+                  {round.subtitle ? <p className={styles.roundSubtitle}>{round.subtitle}</p> : null}
+                  <button
+                    type="button"
+                    id={buttonId}
+                    className={styles.roundToggle}
+                    aria-expanded={isExpanded}
+                    aria-controls={panelId}
+                    onClick={() => toggleRound(round.id)}
+                  >
+                    <span className={styles.roundToggleLabel}>{round.title}</span>
+                    <span className={styles.roundChevron} aria-hidden="true">
+                      {isExpanded ? '▾' : '▸'}
+                    </span>
+                  </button>
                 </div>
               </div>
-              <div className={styles.statusWrapper}>
-                <span className={styles.status} data-status={match.status}>
-                  {match.statusLabel}
-                </span>
-                <a
-                  className={styles.detailsLink}
-                  href={match.detailsUrl}
-                  target="_blank"
-                  rel="noreferrer noopener"
+
+              {isExpanded ? (
+                <div
+                  id={panelId}
+                  role="region"
+                  aria-labelledby={buttonId}
+                  className={styles.roundPanel}
                 >
-                  {match.detailsLabel}
-                </a>
-              </div>
-            </li>
+                  {round.weeks.map((week) => (
+                    <div key={week.id} className={styles.weekBlock}>
+                      <div className={styles.weekHeader}>
+                        <h4 className={styles.weekTitle}>{week.title}</h4>
+                      </div>
+                      <ol className={styles.resultsList} aria-label={`Матчи за ${week.title}`}>
+                        {week.matches.map((match) => {
+                          const scoreLabel = buildScoreLabel(match);
+                          const isHomeWinner = match.winner === 'home';
+                          const isAwayWinner = match.winner === 'away';
+
+                          return (
+                            <li key={match.id} className={styles.resultItem}>
+                              <div className={styles.meta}>
+                                <time dateTime={match.dateTime} className={styles.date}>
+                                  {match.dateLabel}
+                                </time>
+                                {match.stage ? <span className={styles.stage}>{match.stage}</span> : null}
+                              </div>
+                              <div className={styles.teamsMapsWrapper}>
+                                <div className={styles.teams}>
+                                  <div
+                                    className={`${styles.team} ${isHomeWinner ? styles.teamWinner : ''}`}
+                                  >
+                                    <span className={styles.teamName}>{match.teams.home}</span>
+                                  </div>
+                                  <div
+                                    className={styles.scoreWrapper}
+                                    aria-label={`Счёт: ${scoreLabel}`}
+                                  >
+                                    <span className={styles.score} aria-hidden="true">
+                                      <span className={styles.scoreValue}>{match.score.home}</span>
+                                      <span className={styles.scoreSeparator}>—</span>
+                                      <span className={styles.scoreValue}>{match.score.away}</span>
+                                    </span>
+                                    <span
+                                      className={styles.bestOf}
+                                      aria-label={`Формат серии best-of-${match.bestOf}`}
+                                    >
+                                      BO{match.bestOf}
+                                    </span>
+                                  </div>
+                                  <div
+                                    className={`${styles.team} ${isAwayWinner ? styles.teamWinner : ''}`}
+                                  >
+                                    <span className={styles.teamName}>{match.teams.away}</span>
+                                  </div>
+                                </div>
+                                {match.maps?.length ? (
+                                  <div className={styles.maps}>
+                                    <p className={styles.mapsTitle}>Игры</p>
+                                    <ul className={styles.mapList} aria-label={`Игры: ${scoreLabel}`}>
+                                      {match.maps.map((map, index) => {
+                                        const mapLabel = `Игра ${index + 1}`;
+
+                                        return (
+                                          <li key={`${match.id}-${map.id || index}`} className={styles.mapItem}>
+                                            <span className={styles.mapName}>{mapLabel}</span>
+                                            <span className={styles.mapScore}>
+                                              <span className={styles.scoreValue}>{map.score.home}</span>
+                                              <span className={styles.scoreSeparator}>—</span>
+                                              <span className={styles.scoreValue}>{map.score.away}</span>
+                                            </span>
+                                          </li>
+                                        );
+                                      })}
+                                    </ul>
+                                  </div>
+                                ) : null}
+                              </div>
+                              <div className={styles.statusWrapper}>
+                                <span className={styles.status} data-status={match.status}>
+                                  {match.statusLabel}
+                                </span>
+                                <a
+                                  className={styles.detailsLink}
+                                  href={match.detailsUrl}
+                                  target="_blank"
+                                  rel="noreferrer noopener"
+                                >
+                                  {match.detailsLabel}
+                                </a>
+                              </div>
+                            </li>
+                          );
+                        })}
+                      </ol>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </article>
           );
         })}
-      </ol>
+      </div>
     </section>
   );
 };
+
+const mapPropType = PropTypes.shape({
+  id: PropTypes.string,
+  score: PropTypes.shape({
+    home: PropTypes.number.isRequired,
+    away: PropTypes.number.isRequired,
+  }).isRequired,
+});
+
+const matchPropType = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  dateLabel: PropTypes.string.isRequired,
+  dateTime: PropTypes.string.isRequired,
+  stage: PropTypes.string,
+  teams: PropTypes.shape({
+    home: PropTypes.string.isRequired,
+    away: PropTypes.string.isRequired,
+  }).isRequired,
+  score: PropTypes.shape({
+    home: PropTypes.number.isRequired,
+    away: PropTypes.number.isRequired,
+  }).isRequired,
+  maps: PropTypes.arrayOf(mapPropType),
+  bestOf: PropTypes.number.isRequired,
+  status: PropTypes.string.isRequired,
+  statusLabel: PropTypes.string.isRequired,
+  detailsUrl: PropTypes.string.isRequired,
+  detailsLabel: PropTypes.string.isRequired,
+  winner: PropTypes.oneOf(['home', 'away']).isRequired,
+});
 
 MatchResults.propTypes = {
   data: PropTypes.shape({
     title: PropTypes.string.isRequired,
     description: PropTypes.string,
-    matches: PropTypes.arrayOf(
+    rounds: PropTypes.arrayOf(
       PropTypes.shape({
         id: PropTypes.string.isRequired,
-        dateLabel: PropTypes.string.isRequired,
-        dateTime: PropTypes.string.isRequired,
-        stage: PropTypes.string,
-        teams: PropTypes.shape({
-          home: PropTypes.string.isRequired,
-          away: PropTypes.string.isRequired,
-        }).isRequired,
-        score: PropTypes.shape({
-          home: PropTypes.number.isRequired,
-          away: PropTypes.number.isRequired,
-        }).isRequired,
-        bestOf: PropTypes.number.isRequired,
-        status: PropTypes.string.isRequired,
-        statusLabel: PropTypes.string.isRequired,
-        detailsUrl: PropTypes.string.isRequired,
-        detailsLabel: PropTypes.string.isRequired,
-        winner: PropTypes.oneOf(['home', 'away']).isRequired,
+        title: PropTypes.string.isRequired,
+        subtitle: PropTypes.string,
+        defaultExpanded: PropTypes.bool,
+        weeks: PropTypes.arrayOf(
+          PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            title: PropTypes.string.isRequired,
+            matches: PropTypes.arrayOf(matchPropType).isRequired,
+          }),
+        ).isRequired,
       }),
     ).isRequired,
   }).isRequired,

--- a/src/features/MatchResults/MatchResults.module.css
+++ b/src/features/MatchResults/MatchResults.module.css
@@ -23,6 +23,92 @@
   font-size: 1rem;
 }
 
+.rounds {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-3), 1.6vw, var(--space-4));
+}
+
+.round {
+  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--color-surface) 94%, transparent);
+  box-shadow: 0 18px 36px -28px var(--color-shadow-strong);
+}
+
+.roundHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: clamp(var(--space-3), 1.2vw, var(--space-4));
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
+}
+
+.roundMetaWrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.roundSubtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.roundToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  border: none;
+  background: transparent;
+  color: var(--color-text-primary);
+  font-weight: 700;
+  font-size: 1.05rem;
+  cursor: pointer;
+}
+
+.roundToggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 4px;
+  border-radius: var(--radius-sm);
+}
+
+.roundToggleLabel {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.roundChevron {
+  font-size: 1.1rem;
+}
+
+.roundPanel {
+  padding: clamp(var(--space-3), 1.4vw, var(--space-4));
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-3), 1.6vw, var(--space-4));
+}
+
+.weekBlock {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-2), 1vw, var(--space-3));
+}
+
+.weekHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.weekTitle {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
 .resultsList {
   list-style: none;
   margin: 0;
@@ -34,7 +120,7 @@
 
 .resultItem {
   display: grid;
-  grid-template-columns: minmax(8rem, 0.9fr) minmax(0, 1.3fr) minmax(8rem, 0.8fr);
+  grid-template-columns: minmax(8rem, 0.8fr) minmax(0, 1.5fr) minmax(8rem, 0.7fr);
   gap: clamp(var(--space-3), 1.6vw, var(--space-5));
   padding: clamp(var(--space-3), 1.5vw, var(--space-4));
   border-radius: var(--radius-lg);
@@ -60,6 +146,12 @@
 .stage {
   font-size: 0.85rem;
   color: var(--color-text-secondary);
+}
+
+.teamsMapsWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(var(--space-2), 1vw, var(--space-3));
 }
 
 .teams {
@@ -125,6 +217,56 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-text-secondary);
+}
+
+.maps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-surface) 78%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--color-border) 60%, transparent);
+}
+
+.mapsTitle {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-secondary);
+}
+
+.mapList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: var(--space-2);
+}
+
+.mapItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-surface) 60%, transparent);
+}
+
+.mapName {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.mapScore {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-1);
+  font-weight: 700;
+  color: var(--color-text-primary);
 }
 
 .statusWrapper {

--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -1,87 +1,278 @@
 {
   "title": "Результаты последних матчей",
-  "description": "Следите за динамикой плей-офф: счёт, формат серии и быстрые ссылки на повторы.",
-  "matches": [
+  "description": "Следите за динамикой плей-офф: счёт, формат серии, карты и быстрые ссылки на повторы.",
+  "rounds": [
     {
-      "id": "2025-11-17-qual-mi-ne-pushim-ygk",
-      "dateLabel": "17 ноя · 19:00",
-      "dateTime": "2025-11-17T19:00:00+03:00",
-      "stage": "Квалификация · Раунд 1",
-      "teams": {
-        "home": "Mi ne Pushim!",
-        "away": "YGK"
-      },
-      "score": {
-        "home": 2,
-        "away": 0
-      },
-      "bestOf": 3,
-      "status": "finished",
-      "statusLabel": "2–0 · завершён",
-      "detailsUrl": "https://youtu.be/HqTmpiQYUYE?si=m-i_J2KJhgkmmZbB",
-      "detailsLabel": "Смотреть повтор",
-      "winner": "home"
-    },
-     {
-      "id": "2025-11-18-team-borisogleb-ne-znayushchie-pobed",
-      "dateLabel": "19 ноя · 19:00",
-      "timeLabel": "19:00",
-      "dateTime": "2025-11-18T19:00:00+03:00",
-      "stage": "Квалификация · Раунд 1",
-      "teams": {
-        "home": "Team Borisogleb",
-        "away": "Не Знающие Побед"
-      },
-      "score": {
-        "home": 2,
-        "away": 0
-      },
-      "bestOf": 3,
-      "status": "finished",
-      "statusLabel": "2–0 · завершён",
-       "detailsUrl": "https://youtu.be/fOa2SLn0U6w?si=DzZKJYETDOTCEixa",
-      "detailsLabel": "Смотреть повтор",
-      "winner": "home"
-    },
-    {
-      "id": "2025-11-19-japan-blyzhayshie",
-      "dateLabel": "19 ноя · 20:00",
-      "dateTime": "2025-11-19T20:00:00+03:00",
-      "stage": "Квалификация · Раунд 1",
-      "teams": {
-        "home": "Japan 日本",
-        "away": "Ближайшие"
-      },
-      "score": {
-        "home": 2,
-        "away": 0
-      },
-      "bestOf": 3,
-      "status": "finished",
-      "statusLabel": "2–0 · завершён",
-      "detailsUrl": "https://youtu.be/Y21MEipmu10?si=sJAv8cqWqh6msFqV",
-      "detailsLabel": "Смотреть повтор",
-      "winner": "home"
-    },
-    {
-      "id": "2025-11-20-yellow-submarine-arb-esports",
-      "dateLabel": "20 ноя · 20:00",
-      "dateTime": "2025-11-20T20:00:00+03:00",
-      "stage": "Квалификация · Раунд 1",
-      "teams": {
-        "home": "Yellow Submarine",
-        "away": "ARB esports"
-      },
-      "score": {
-        "home": 0,
-        "away": 2
-      },
-      "bestOf": 3,
-      "status": "finished",
-      "statusLabel": "0–2 · завершён",
-      "detailsUrl": "https://youtu.be/Y21MEipmu10?si=..",
-      "detailsLabel": "Смотреть повтор",
-      "winner": "away"
-   }
+      "id": "round-1",
+      "title": "Результаты 1-го круга",
+      "subtitle": "Групповой этап",
+      "defaultExpanded": false,
+      "weeks": [
+        {
+          "id": "week-1",
+          "title": "Неделя 1 · 17–20 ноября",
+          "matches": [
+            {
+              "id": "2025-11-17-qual-mi-ne-pushim-ygk",
+              "dateLabel": "17 ноя · 19:00",
+              "dateTime": "2025-11-17T19:00:00+03:00",
+              "stage": "Круг 1 · Неделя 1",
+              "teams": {
+                "home": "Mi ne Pushim!",
+                "away": "YGK"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 33,
+                    "away": 3
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 39,
+                    "away": 27
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://youtu.be/HqTmpiQYUYE?si=m-i_J2KJhgkmmZbB",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2025-11-18-team-borisogleb-ne-znayushchie-pobed",
+              "dateLabel": "18 ноя · 19:00",
+              "dateTime": "2025-11-18T19:00:00+03:00",
+              "stage": "Круг 1 · Неделя 1",
+              "teams": {
+                "home": "Team Borisogleb",
+                "away": "Не Знающие Побед"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 24,
+                    "away": 12
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 31,
+                    "away": 18
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://youtu.be/fOa2SLn0U6w?si=DzZKJYETDOTCEixa",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2025-11-19-japan-blyzhayshie",
+              "dateLabel": "19 ноя · 20:00",
+              "dateTime": "2025-11-19T20:00:00+03:00",
+              "stage": "Круг 1 · Неделя 1",
+              "teams": {
+                "home": "Japan 日本",
+                "away": "Ближайшие"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 28,
+                    "away": 10
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 30,
+                    "away": 21
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://youtu.be/Y21MEipmu10?si=sJAv8cqWqh6msFqV",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2025-11-20-yellow-submarine-arb-esports",
+              "dateLabel": "20 ноя · 20:00",
+              "dateTime": "2025-11-20T20:00:00+03:00",
+              "stage": "Круг 1 · Неделя 1",
+              "teams": {
+                "home": "Yellow Submarine",
+                "away": "ARB esports"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 16,
+                    "away": 30
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 19,
+                    "away": 33
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://youtu.be/Y21MEipmu10?si=..",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            }
+          ]
+        },
+        {
+          "id": "week-2",
+          "title": "Неделя 2 · 21–23 ноября",
+          "matches": [
+            {
+              "id": "2025-11-21-steel-titans-labubu-team",
+              "dateLabel": "21 ноя · 19:00",
+              "dateTime": "2025-11-21T19:00:00+03:00",
+              "stage": "Круг 1 · Неделя 2",
+              "teams": {
+                "home": "Steel Titans",
+                "away": "Labubu Team"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 32,
+                    "away": 15
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 34,
+                    "away": 18
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://youtu.be/dummy-steel-titans-labubu",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2025-11-21-way-prod-geeks",
+              "dateLabel": "21 ноя · 19:00",
+              "dateTime": "2025-11-21T19:00:00+03:00",
+              "stage": "Круг 1 · Неделя 2",
+              "teams": {
+                "home": "Way prod",
+                "away": "Гики"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 31,
+                    "away": 22
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 29,
+                    "away": 17
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://youtu.be/dummy-way-prod-geeks",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2025-11-23-tech-titans-buyback-academy",
+              "dateLabel": "23 ноя · 15:00",
+              "dateTime": "2025-11-23T15:00:00+03:00",
+              "stage": "Круг 1 · Неделя 2",
+              "teams": {
+                "home": "Tech Titans",
+                "away": "Buyback academy"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 33,
+                    "away": 29
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 30,
+                    "away": 21
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://youtu.be/dummy-tech-titans-buyback",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            }
+          ]
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- rename per-map score labels in MatchResults to show generic games instead of maps
- adjust accordion aria labels accordingly to match the new terminology

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924198713c483238291d257436c7270)