### PR TITLE
Compact match results layout

### DIFF
--- a/src/features/MatchResults/MatchResults.module.css
+++ b/src/features/MatchResults/MatchResults.module.css
@@ -84,10 +84,10 @@
 }
 
 .roundPanel {
-  padding: clamp(var(--space-3), 1.4vw, var(--space-4));
+  padding: clamp(var(--space-2), 1vw, var(--space-3));
   display: flex;
   flex-direction: column;
-  gap: clamp(var(--space-3), 1.6vw, var(--space-4));
+  gap: clamp(var(--space-2), 1vw, var(--space-3));
 }
 
 .weekBlock {
@@ -115,14 +115,14 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: clamp(var(--space-2), 0.8vw, var(--space-3));
 }
 
 .resultItem {
   display: grid;
   grid-template-columns: minmax(8rem, 0.8fr) minmax(0, 1.5fr) minmax(8rem, 0.7fr);
-  gap: clamp(var(--space-3), 1.6vw, var(--space-5));
-  padding: clamp(var(--space-3), 1.5vw, var(--space-4));
+  gap: clamp(var(--space-2), 1vw, var(--space-3));
+  padding: clamp(var(--space-2), 1.2vw, var(--space-3));
   border-radius: var(--radius-lg);
   background: color-mix(in srgb, var(--color-surface) 88%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
@@ -151,7 +151,7 @@
 .teamsMapsWrapper {
   display: flex;
   flex-direction: column;
-  gap: clamp(var(--space-2), 1vw, var(--space-3));
+  gap: clamp(var(--space-1), 0.8vw, var(--space-2));
 }
 
 .teams {
@@ -187,7 +187,7 @@
   flex-direction: column;
   align-items: center;
   gap: var(--space-1);
-  padding: 0.75rem 1rem;
+  padding: 0.45rem 0.75rem;
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--color-surface) 50%, rgba(255, 255, 255, 0.08));
   border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
@@ -212,7 +212,7 @@
 }
 
 .bestOf {
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -223,7 +223,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
-  padding: var(--space-2);
+  padding: clamp(var(--space-1), 0.8vw, var(--space-2));
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--color-surface) 78%, transparent);
   border: 1px dashed color-mix(in srgb, var(--color-border) 60%, transparent);
@@ -244,20 +244,22 @@
   padding: 0;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
-  gap: var(--space-2);
+  gap: clamp(var(--space-1), 0.8vw, var(--space-2));
 }
 
 .mapItem {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 0.9rem;
+  padding: 0.55rem 0.75rem;
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--color-surface) 60%, transparent);
 }
 
 .mapName {
   font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1.2;
   color: var(--color-text-primary);
 }
 
@@ -265,6 +267,8 @@
   display: inline-flex;
   align-items: baseline;
   gap: var(--space-1);
+  font-size: 0.95rem;
+  line-height: 1.2;
   font-weight: 700;
   color: var(--color-text-primary);
 }


### PR DESCRIPTION
## Summary
- reduce padding and gaps in match result sections to shrink overall card height
- tighten score and map typography for a denser layout while preserving readability
- capture updated desktop and mobile UI snapshots for the compact match results block

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692444aa303083239e1da1591775b4c2)