### PR TITLE
Add team logos to upcoming matches

### DIFF
--- a/src/features/UpcomingMatches/UpcomingMatches.jsx
+++ b/src/features/UpcomingMatches/UpcomingMatches.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { getTeamLogo } from '../../utils/teamLogos';
 import styles from './UpcomingMatches.module.css';
 
 const UpcomingMatches = ({ data }) => {
@@ -36,9 +37,31 @@ const UpcomingMatches = ({ data }) => {
                 </time>
               </div>
               <div className={styles.teams}>
-                <span className={styles.teamName}>{match.teams.home}</span>
-                <span className={styles.separator}>—</span>
-                <span className={styles.teamName}>{match.teams.away}</span>
+                {['home', 'away'].map((side) => {
+                  const teamName = match.teams[side];
+                  const teamLogo = getTeamLogo(teamName);
+
+                  return (
+                    <span key={side} className={styles.team}>
+                      {teamLogo ? (
+                        <img
+                          src={teamLogo}
+                          alt={`Логотип команды ${teamName}`}
+                          className={styles.teamLogo}
+                          loading="lazy"
+                          width={28}
+                          height={28}
+                        />
+                      ) : null}
+                      <span className={styles.teamName}>{teamName}</span>
+                      {side === 'home' ? (
+                        <span className={styles.separator} aria-hidden="true">
+                          —
+                        </span>
+                      ) : null}
+                    </span>
+                  );
+                })}
               </div>
               <div className={styles.channels}>
                 {channels.map((channel) => (

--- a/src/features/UpcomingMatches/UpcomingMatches.module.css
+++ b/src/features/UpcomingMatches/UpcomingMatches.module.css
@@ -90,8 +90,21 @@
   color: var(--color-text-primary);
 }
 
+.team {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
 .teamName {
   white-space: nowrap;
+}
+
+.teamLogo {
+  width: 1.75rem;
+  height: 1.75rem;
+  object-fit: contain;
+  flex-shrink: 0;
 }
 
 .separator {

--- a/src/utils/teamLogos.js
+++ b/src/utils/teamLogos.js
@@ -1,0 +1,54 @@
+import teamShowcaseConfig from '../features/team-showcase/config.json';
+
+const normalizeTeamName = (name) =>
+  name
+    ? name
+        .trim()
+        .toLowerCase()
+        .replace(/\.(jpg|jpeg|png|svg|webp)$/i, '')
+        .replace(/[^\p{L}\p{N}]+/gu, '')
+    : '';
+
+const teamLogosMap = teamShowcaseConfig.reduce((acc, team) => {
+  if (!team || typeof team !== 'object') {
+    return acc;
+  }
+
+  const { name, logo } = team;
+
+  if (!name || !logo) {
+    return acc;
+  }
+
+  acc[name] = logo;
+
+  const normalizedName = normalizeTeamName(name);
+
+  if (normalizedName && !acc[normalizedName]) {
+    acc[normalizedName] = logo;
+  }
+
+  return acc;
+}, {});
+
+const TEAM_LOGO_ALIASES = {
+  arb: 'arbesports',
+};
+
+const getTeamLogo = (name) => {
+  if (!name) {
+    return null;
+  }
+
+  const normalizedName = normalizeTeamName(name);
+  const alias = TEAM_LOGO_ALIASES[normalizedName];
+
+  return (
+    teamLogosMap[name] ??
+    teamLogosMap[normalizedName] ??
+    (alias ? teamLogosMap[alias] : null) ??
+    null
+  );
+};
+
+export { getTeamLogo, normalizeTeamName, teamLogosMap };


### PR DESCRIPTION
## Summary
- add reusable team logo lookup derived from team showcase config
- render team logos alongside upcoming match participants with accessible alt text
- adjust upcoming matches styles to align icons with team names

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692446daa8a88323936b7848a264735f)