### PR TITLE
fix: stabilize qualifications table layout

### DIFF
--- a/src/features/QualificationsTable/QualificationsTable.module.css
+++ b/src/features/QualificationsTable/QualificationsTable.module.css
@@ -107,8 +107,27 @@
 
 .table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
   min-width: 720px;
+}
+
+.table th:nth-child(1),
+.table td:nth-child(1) {
+  width: 120px;
+  max-width: 140px;
+}
+
+.table th:nth-child(6),
+.table td:nth-child(6) {
+  width: 150px;
+  max-width: 180px;
+}
+
+.table th:nth-child(7),
+.table td:nth-child(7) {
+  width: 120px;
+  max-width: 150px;
 }
 
 .table thead {
@@ -139,7 +158,9 @@
 }
 
 .teamCell {
-  min-width: 180px;
+  min-width: 200px;
+  max-width: 320px;
+  word-break: break-word;
 }
 
 .teamName {
@@ -157,6 +178,7 @@
   display: flex;
   align-items: center;
   gap: 0.35rem;
+  flex: 0 0 auto;
 }
 
 .positionValue {
@@ -255,6 +277,24 @@
 
   .table {
     min-width: 100%;
+  }
+
+  .table th:nth-child(1),
+  .table td:nth-child(1) {
+    width: 104px;
+    max-width: 120px;
+  }
+
+  .table th:nth-child(6),
+  .table td:nth-child(6) {
+    width: 136px;
+    max-width: 160px;
+  }
+
+  .table th:nth-child(7),
+  .table td:nth-child(7) {
+    width: 110px;
+    max-width: 130px;
   }
 
   .table th,


### PR DESCRIPTION
## Summary
- add fixed table layout with explicit widths for position, maps, and points columns
- constrain position and team cells to keep long names from breaking the grid
- adjust responsive column widths to preserve mobile layout with existing media rules

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244a1a7ec48323847d0a91537a3d1c)