### PR TITLE
Add team logos to match results

### DIFF
--- a/src/features/MatchResults/MatchResults.jsx
+++ b/src/features/MatchResults/MatchResults.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
+import { getTeamLogo } from '../../utils/teamLogos';
 import styles from './MatchResults.module.css';
 
 const MatchResults = ({ data }) => {
@@ -17,6 +18,28 @@ const MatchResults = ({ data }) => {
 
   const buildScoreLabel = (match) =>
     `${match.teams.home} ${match.score.home} — ${match.score.away} ${match.teams.away} · BO${match.bestOf}`;
+
+  const renderTeam = (match, side) => {
+    const teamName = match.teams[side];
+    const teamLogo = getTeamLogo(teamName);
+    const isWinner = match.winner === side;
+
+    return (
+      <div className={`${styles.team} ${isWinner ? styles.teamWinner : ''}`}>
+        {teamLogo ? (
+          <img
+            src={teamLogo}
+            alt={`Логотип команды ${teamName}`}
+            className={styles.teamLogo}
+            loading="lazy"
+            width={32}
+            height={32}
+          />
+        ) : null}
+        <span className={styles.teamName}>{teamName}</span>
+      </div>
+    );
+  };
 
   const toggleRound = (roundId) => {
     setExpandedRounds((prev) => ({
@@ -78,8 +101,6 @@ const MatchResults = ({ data }) => {
                       <ol className={styles.resultsList} aria-label={`Матчи за ${week.title}`}>
                         {week.matches.map((match) => {
                           const scoreLabel = buildScoreLabel(match);
-                          const isHomeWinner = match.winner === 'home';
-                          const isAwayWinner = match.winner === 'away';
 
                           return (
                             <li key={match.id} className={styles.resultItem}>
@@ -91,11 +112,7 @@ const MatchResults = ({ data }) => {
                               </div>
                               <div className={styles.teamsMapsWrapper}>
                                 <div className={styles.teams}>
-                                  <div
-                                    className={`${styles.team} ${isHomeWinner ? styles.teamWinner : ''}`}
-                                  >
-                                    <span className={styles.teamName}>{match.teams.home}</span>
-                                  </div>
+                                  {renderTeam(match, 'home')}
                                   <div
                                     className={styles.scoreWrapper}
                                     aria-label={`Счёт: ${scoreLabel}`}
@@ -112,11 +129,7 @@ const MatchResults = ({ data }) => {
                                       BO{match.bestOf}
                                     </span>
                                   </div>
-                                  <div
-                                    className={`${styles.team} ${isAwayWinner ? styles.teamWinner : ''}`}
-                                  >
-                                    <span className={styles.teamName}>{match.teams.away}</span>
-                                  </div>
+                                  {renderTeam(match, 'away')}
                                 </div>
                                 {match.maps?.length ? (
                                   <div className={styles.maps}>

--- a/src/features/MatchResults/MatchResults.module.css
+++ b/src/features/MatchResults/MatchResults.module.css
@@ -156,15 +156,18 @@
 
 .teams {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
   align-items: center;
   gap: clamp(var(--space-2), 1vw, var(--space-3));
+  column-gap: clamp(var(--space-3), 1vw + var(--space-2), var(--space-4));
 }
 
 .team {
   display: flex;
   align-items: center;
   justify-content: flex-start;
+  gap: clamp(var(--space-1), 0.8vw, var(--space-2));
+  min-width: 0;
 }
 
 .team:nth-child(3) {
@@ -175,11 +178,24 @@
   font-size: clamp(1rem, 0.9rem + 0.4vw, 1.25rem);
   font-weight: 600;
   color: var(--color-text-primary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .teamWinner .teamName {
   color: var(--color-accent-strong, var(--color-accent));
   text-shadow: 0 0 16px color-mix(in srgb, var(--color-accent) 40%, transparent);
+}
+
+.teamLogo {
+  width: 2.25rem;
+  height: 2.25rem;
+  object-fit: contain;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-surface) 70%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 60%, transparent);
 }
 
 .scoreWrapper {


### PR DESCRIPTION
## Summary
- render team logos in match results using the shared logo map with a text fallback
- update team grid styling to fit the new icons while keeping winner highlighting

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244ad0e75c832389df7313e03971fd)