### PR TITLE
Add team logos to qualifications table

### DIFF
--- a/src/features/QualificationsTable/QualificationsTable.jsx
+++ b/src/features/QualificationsTable/QualificationsTable.jsx
@@ -155,9 +155,27 @@ const QualificationsTable = ({ data, matchResults }) => {
                   </span>
                 </th>
                 <td className={styles.teamCell}>
-                  <div className={styles.teamName}>{team.name}</div>
-                  <div className={styles.teamMeta} aria-hidden="true">
-                    {team.wins}–{team.losses} · карты {team.mapWins}:{team.mapLosses}
+                  <div className={styles.teamIdentity}>
+                    {team.logo ? (
+                      <img
+                        src={team.logo}
+                        alt={`Логотип команды ${team.name}`}
+                        className={styles.teamLogo}
+                        loading="lazy"
+                        width={44}
+                        height={44}
+                      />
+                    ) : (
+                      <div className={styles.teamLogoFallback} aria-hidden="true">
+                        {team.name?.[0] ?? '?'}
+                      </div>
+                    )}
+                    <div className={styles.teamText}>
+                      <div className={styles.teamName}>{team.name}</div>
+                      <div className={styles.teamMeta} aria-hidden="true">
+                        {team.wins}–{team.losses} · карты {team.mapWins}:{team.mapLosses}
+                      </div>
+                    </div>
                   </div>
                 </td>
                 <td className={styles.numeric}>{team.matches}</td>

--- a/src/features/QualificationsTable/QualificationsTable.module.css
+++ b/src/features/QualificationsTable/QualificationsTable.module.css
@@ -158,14 +158,52 @@
 }
 
 .teamCell {
-  min-width: 200px;
-  max-width: 320px;
+  min-width: 220px;
+  max-width: 360px;
   word-break: break-word;
+}
+
+.teamIdentity {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.teamLogo {
+  width: 44px;
+  height: 44px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+}
+
+.teamLogoFallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  color: var(--color-text-primary);
+  font-weight: 700;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  text-transform: uppercase;
+}
+
+.teamText {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
 }
 
 .teamName {
   font-weight: 600;
   color: var(--color-text-primary);
+  line-height: 1.3;
 }
 
 .teamMeta {

--- a/src/features/QualificationsTable/standings.js
+++ b/src/features/QualificationsTable/standings.js
@@ -1,4 +1,5 @@
 import slugify from '../../utils/slugify.js';
+import { getTeamLogo } from '../../utils/teamLogos.js';
 
 export const calculateMapDiff = (team) => team.mapWins - team.mapLosses;
 
@@ -13,10 +14,17 @@ const ensureTeam = (teamsMap, name) => {
       mapWins: 0,
       mapLosses: 0,
       points: 0,
+      logo: getTeamLogo(name),
     });
   }
 
-  return teamsMap.get(name);
+  const team = teamsMap.get(name);
+
+  if (!team.logo) {
+    team.logo = getTeamLogo(name);
+  }
+
+  return team;
 };
 
 const toNumber = (value) => (Number.isFinite(value) ? value : 0);

--- a/src/features/QualificationsTable/standings.test.js
+++ b/src/features/QualificationsTable/standings.test.js
@@ -28,6 +28,7 @@ test('buildStandingsFromMatchResults aggregates finished matches into standings'
     mapWins: 2,
     mapLosses: 0,
     points: 2,
+    logo: '/logos/Mi Ne Pushim.jpg',
   });
 
   const uniqueIds = new Set(standings.map((team) => team.id));

--- a/src/utils/teamLogos.js
+++ b/src/utils/teamLogos.js
@@ -1,4 +1,4 @@
-import teamShowcaseConfig from '../features/team-showcase/config.json';
+import teamShowcaseConfig from '../features/team-showcase/config.json' with { type: 'json' };
 
 const normalizeTeamName = (name) =>
   name


### PR DESCRIPTION
## Summary
- add roster logo lookup to qualifications standings
- render team thumbnails in the qualifications table with refreshed spacing styles
- adjust tests and team logo utility for JSON import compatibility

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244b3f95448323af87dda509124ddd)