### PR TITLE
Fix qualifications table row divider rendering

### DIFF
--- a/src/features/QualificationsTable/QualificationsTable.module.css
+++ b/src/features/QualificationsTable/QualificationsTable.module.css
@@ -139,8 +139,19 @@
 .table td {
   padding: clamp(0.75rem, 2vw, 1rem) clamp(0.6rem, 1.5vw, 0.9rem);
   text-align: left;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   font-variant-numeric: tabular-nums;
+}
+
+.table tbody tr {
+  position: relative;
+}
+
+.table tbody tr::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  pointer-events: none;
 }
 
 .table th {


### PR DESCRIPTION
## Summary
- move table row dividers from individual cells to row pseudo-elements for full-width lines
- retain hover and striped row styling while ensuring dividers stay aligned

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244cc9b594832381fde9f885fb9fbf)