### PR TITLE
Remove update note from qualifications table

### DIFF
--- a/src/features/QualificationsTable/QualificationsTable.jsx
+++ b/src/features/QualificationsTable/QualificationsTable.jsx
@@ -18,7 +18,6 @@ const QualificationsTable = ({ data, matchResults }) => {
   );
 
   const finishedWeeks = useMemo(() => extractFinishedMatchesByWeek(matchResults), [matchResults]);
-  const latestFinishedWeek = finishedWeeks[finishedWeeks.length - 1];
 
   const previousWeekMatches = useMemo(
     () => finishedWeeks.slice(0, -1).flatMap((week) => week.matches),
@@ -66,11 +65,6 @@ const QualificationsTable = ({ data, matchResults }) => {
             {title}
           </h3>
           <p className={styles.description}>{description}</p>
-          {latestFinishedWeek ? (
-            <p className={styles.updateNote}>
-              Обновлено по итогам: <span className={styles.updateHighlight}>{latestFinishedWeek.title}</span>
-            </p>
-          ) : null}
         </div>
         <div className={styles.controls} aria-label="Управление сортировкой таблицы">
           <span className={styles.controlsLabel}>Сортировка:</span>

--- a/src/features/QualificationsTable/QualificationsTable.module.css
+++ b/src/features/QualificationsTable/QualificationsTable.module.css
@@ -30,28 +30,9 @@
 }
 
 .description {
-  margin: 0;
+  margin: 0 0 var(--space-2);
   color: var(--color-text-secondary);
   line-height: 1.5;
-}
-
-.updateNote {
-  margin: var(--space-2) 0 0;
-  color: var(--color-text-muted);
-  font-size: 0.95rem;
-}
-
-.updateHighlight {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.35rem 0.65rem;
-  margin-left: 0.35rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  color: var(--color-text-primary);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- stop rendering the outdated “Обновлено по итогам” note in the qualifications table
- clean up unused styles and adjust description spacing to keep layout consistent

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692450654c348323a63c27ebf44394e9)