### PR TITLE
fix: adjust qualifications table layout on mobile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,6 +74,7 @@ const App = () => {
       navLabel: 'Таблица',
       variant: 'qualifications-table',
       hideTitle: true,
+      fullBleed: true,
     },
     {
       id: 'match-results',

--- a/src/components/Section.css
+++ b/src/components/Section.css
@@ -67,6 +67,8 @@
   background: transparent;
   border: none;
   box-shadow: none;
+  border-radius: 0;
+  overflow: visible;
 }
 
 .section--hero {

--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -18,7 +18,7 @@
               "dateTime": "2025-11-17T19:00:00+03:00",
               "stage": "Круг 1 · Неделя 1",
               "teams": {
-                "home": "Mi Ne Pushim!",
+                "home": "Mi ne Pushim!",
                 "away": "YGK"
               },
               "score": {

--- a/src/features/QualificationsTable/QualificationsTable.jsx
+++ b/src/features/QualificationsTable/QualificationsTable.jsx
@@ -175,6 +175,11 @@ const QualificationsTable = ({ data, matchResults }) => {
           </tbody>
         </table>
       </div>
+
+      <p className={styles.mobileNotice} role="note">
+        Таблица доступна на десктопных устройствах. Откройте сайт на более широком экране,
+        чтобы посмотреть расписание и результаты.
+      </p>
     </section>
   );
 };

--- a/src/features/QualificationsTable/QualificationsTable.module.css
+++ b/src/features/QualificationsTable/QualificationsTable.module.css
@@ -1,8 +1,9 @@
 .wrapper {
-  width: 100%;
+  --wrapper-padding: clamp(var(--space-6), 4vw, var(--space-7));
+  width: min(100%, var(--max-width));
   max-width: var(--max-width);
-  margin: 0 auto;
-  padding: clamp(var(--space-6), 4vw, var(--space-7));
+  margin-inline: auto;
+  padding: var(--wrapper-padding);
   background: linear-gradient(145deg, rgba(20, 25, 54, 0.8), rgba(15, 19, 42, 0.94));
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-lg);
@@ -80,7 +81,8 @@
 }
 
 .tableContainer {
-  width: 100%;
+  width: calc(100% + calc(var(--wrapper-padding) * 2));
+  margin-inline: calc(var(--wrapper-padding) * -1);
   overflow-x: auto;
   border-radius: var(--radius-md);
   border: 1px solid rgba(255, 255, 255, 0.1);
@@ -251,15 +253,34 @@
   justify-content: center;
 }
 
+.mobileNotice {
+  display: none;
+  margin-top: var(--space-4);
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px dashed rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
 @media (max-width: 768px) {
   .wrapper {
     padding: var(--space-5);
   }
 
   .controls {
+    display: none;
+  }
+
+  .controls {
     width: 100%;
     justify-content: space-between;
     flex-wrap: wrap;
+  }
+
+  .tableContainer {
+    display: none;
   }
 
   .sortButtons {
@@ -292,6 +313,10 @@
   .table th,
   .table td {
     padding: 0.75rem 0.65rem;
+  }
+
+  .mobileNotice {
+    display: block;
   }
 }
 


### PR DESCRIPTION
## Summary
- extend the qualifications table container to the wrapper edges to remove the right-side gap
- hide the qualifications table on mobile and show a user-facing notice about desktop availability

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692454f4ddec8323ad4f095acca38c68)