### PR TITLE
Enhance auth page styling and routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "spa-feature-template",
       "version": "0.0.1",
       "dependencies": {
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -3573,7 +3574,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3881,7 +3881,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -3949,7 +3948,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "node --test"
   },
   "dependencies": {
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,0 +1,93 @@
+import PropTypes from 'prop-types';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+const TOKEN_STORAGE_KEY = 'authToken';
+
+const AuthContext = createContext({
+  token: null,
+  setToken: () => undefined,
+  signOut: () => undefined,
+});
+
+const readStoredToken = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const storages = [window.localStorage, window.sessionStorage];
+
+  for (const storage of storages) {
+    const stored = storage.getItem(TOKEN_STORAGE_KEY);
+    if (stored) {
+      return stored;
+    }
+  }
+
+  return null;
+};
+
+const persistToken = (token, remember) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const primaryStorage = remember ? window.localStorage : window.sessionStorage;
+  const secondaryStorage = remember ? window.sessionStorage : window.localStorage;
+
+  if (token) {
+    primaryStorage.setItem(TOKEN_STORAGE_KEY, token);
+    secondaryStorage.removeItem(TOKEN_STORAGE_KEY);
+    return;
+  }
+
+  primaryStorage.removeItem(TOKEN_STORAGE_KEY);
+  secondaryStorage.removeItem(TOKEN_STORAGE_KEY);
+};
+
+export const AuthProvider = ({ children }) => {
+  const [token, setTokenState] = useState(() => readStoredToken());
+
+  const setToken = useCallback((newToken, options = {}) => {
+    const remember = options.remember ?? true;
+    setTokenState(newToken);
+    persistToken(newToken, remember);
+  }, []);
+
+  const signOut = useCallback(() => {
+    setTokenState(null);
+    persistToken(null, true);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const handleStorage = (event) => {
+      if (event.key !== TOKEN_STORAGE_KEY) {
+        return;
+      }
+      setTokenState(event.newValue);
+    };
+
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      token,
+      setToken,
+      signOut,
+    }),
+    [token, setToken, signOut],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/features/auth/AuthPage.css
+++ b/src/features/auth/AuthPage.css
@@ -1,0 +1,123 @@
+.auth-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-7) var(--space-5);
+  background:
+    var(--decor-pattern-celestial),
+    var(--decor-pattern-aurora),
+    var(--decor-pattern-lotus),
+    var(--decor-gradient-haze);
+}
+
+.auth-card {
+  width: min(480px, 100%);
+  padding: var(--space-7);
+  border-radius: var(--radius-xl);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft-elevated), var(--shadow-ambient-glow);
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.auth-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.auth-card__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 2vw, 1.9rem);
+  letter-spacing: 0.02em;
+}
+
+.auth-card__subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.auth-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.auth-form__label {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.auth-form__input {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-card);
+  color: var(--color-text-primary);
+  transition: border-color var(--transition-normal), box-shadow var(--transition-normal);
+}
+
+.auth-form__input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 4px var(--color-primary-soft);
+}
+
+.auth-form__checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--color-text-secondary);
+}
+
+.auth-form__error {
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  background: rgba(251, 113, 133, 0.12);
+  color: var(--color-danger);
+  border: 1px solid rgba(251, 113, 133, 0.4);
+}
+
+.auth-form__submit {
+  margin-top: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius-md);
+  border: none;
+  background: var(--gradient-primary);
+  color: #0b0e1a;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  transition: transform var(--transition-fast), box-shadow var(--transition-normal);
+}
+
+.auth-form__submit:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.auth-form__submit:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(139, 123, 255, 0.25);
+}
+
+.auth-form__submit:not(:disabled):active {
+  transform: translateY(0);
+}
+
+.auth-card__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  line-height: 1.4;
+}

--- a/src/features/auth/AuthPage.jsx
+++ b/src/features/auth/AuthPage.jsx
@@ -1,0 +1,112 @@
+import { useMemo, useState } from 'react';
+import { useAuth } from '../../context/AuthContext.jsx';
+import './AuthPage.css';
+
+const AuthPage = () => {
+  const { setToken } = useAuth();
+  const [login, setLogin] = useState('');
+  const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(true);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const submitDisabled = useMemo(
+    () => loading || !login.trim() || !password.trim(),
+    [loading, login, password],
+  );
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      const response = await fetch('/api/auth/sign-in', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ login, password }),
+      });
+
+      const payload = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        throw new Error(payload?.message || 'Не удалось выполнить вход');
+      }
+
+      if (!payload?.token) {
+        throw new Error('Токен не получен от сервера');
+      }
+
+      setToken(payload.token, { remember: rememberMe });
+    } catch (err) {
+      setError(err.message || 'Произошла ошибка при выполнении запроса');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="auth-page">
+      <section className="auth-card" aria-labelledby="auth-title">
+        <header className="auth-card__header">
+          <h1 id="auth-title" className="auth-card__title">
+            Войти в аккаунт
+          </h1>
+          <p className="auth-card__subtitle">
+            Получите доступ к закрытым разделам платформы, используя свои учетные данные.
+          </p>
+        </header>
+        <form className="auth-form" onSubmit={handleSubmit} noValidate>
+          <label className="auth-form__field">
+            <span className="auth-form__label">Логин</span>
+            <input
+              className="auth-form__input"
+              type="text"
+              value={login}
+              onChange={(event) => setLogin(event.target.value)}
+              required
+              autoComplete="username"
+              placeholder="Введите логин"
+            />
+          </label>
+          <label className="auth-form__field">
+            <span className="auth-form__label">Пароль</span>
+            <input
+              className="auth-form__input"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              autoComplete="current-password"
+              placeholder="Введите пароль"
+            />
+          </label>
+          <label className="auth-form__checkbox-row">
+            <input
+              type="checkbox"
+              checked={rememberMe}
+              onChange={(event) => setRememberMe(event.target.checked)}
+            />
+            <span>Запомнить меня</span>
+          </label>
+          {error ? (
+            <div className="auth-form__error" role="alert">
+              {error}
+            </div>
+          ) : null}
+          <button className="auth-form__submit" type="submit" disabled={submitDisabled}>
+            {loading ? 'Входим...' : 'Войти'}
+          </button>
+        </form>
+        <p className="auth-card__hint">
+          Убедитесь, что используете корпоративные учетные данные. Если не удается войти, попробуйте
+          снять отметку «Запомнить меня» и повторите попытку.
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default AuthPage;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,18 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import AuthPage from './features/auth/AuthPage.jsx';
+import { AuthProvider } from './context/AuthContext.jsx';
 import './styles/base.css';
+
+const Root = () => {
+  const isAuthRoute = typeof window !== 'undefined' && window.location.pathname.startsWith('/auth');
+
+  return <AuthProvider>{isAuthRoute ? <AuthPage /> : <App />}</AuthProvider>;
+};
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <Root />
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- add dedicated styling and UX polish for the authentication page
- gate the root render to show the auth page on the /auth route while keeping the provider
- refine form validation with disabled submit state and helper copy

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256a39ceac8323813638c5169166d1)