### PR TITLE
Update round two match schedule and results

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -319,6 +319,42 @@
               "detailsUrl": "https://youtu.be/steel-titans-way-prod",
               "detailsLabel": "Смотреть повтор",
               "winner": "away"
+            },
+            {
+              "id": "2025-11-26-yellow-submarine-ne-znayushchie-pobed",
+              "dateLabel": "26 ноя · 19:00",
+              "dateTime": "2025-11-26T19:00:00+03:00",
+              "stage": "Круг 2 · Неделя 1",
+              "teams": {
+                "home": "Yellow Submarine",
+                "away": "Не Знающие Побед"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 41,
+                    "away": 36
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 32,
+                    "away": 13
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://youtu.be/yellow-submarine-ne-znayushchie-pobed",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
             }
           ]
         }

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -20,17 +20,6 @@
   },
   "matches": [
     {
-      "id": "2025-11-26-ne-znayushchie-pobed-yellow-submarine",
-      "dayLabel": "Ср 26.11",
-      "timeLabel": "19:00",
-      "dateTime": "2025-11-26T19:00:00+03:00",
-      "teams": {
-        "home": "Не Знающие Побед",
-        "away": "Yellow Submarine"
-      },
-      "channelIds": ["primary"]
-    },
-    {
       "id": "2025-11-27-arb-buyback-academy",
       "dayLabel": "Чт 27.11",
       "timeLabel": "19:00",


### PR DESCRIPTION
## Summary
- remove the completed Yellow Submarine vs Не Знающие Побед fixture from upcoming matches
- add the 26 Nov round 2 result with map scores to the match results feed

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927722d1e3883239b6e5beb0a7d6741)