### PR TITLE
Update Labubu Team vs Geeks result

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -470,6 +470,49 @@
               "detailsUrl": "https://youtu.be/mi-ne-pushim-japan-27-nov",
               "detailsLabel": "Смотреть повтор",
               "winner": "away"
+            },
+            {
+              "id": "2025-11-28-labubu-team-geeks",
+              "dateLabel": "28 ноя · 19:00",
+              "dateTime": "2025-11-28T19:00:00+03:00",
+              "stage": "Круг 2",
+              "teams": {
+                "home": "Labubu Team",
+                "away": "Гики"
+              },
+              "score": {
+                "home": 2,
+                "away": 1
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 21,
+                    "away": 38
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 45,
+                    "away": 7
+                  }
+                },
+                {
+                  "id": "game-3",
+                  "score": {
+                    "home": 45,
+                    "away": 7
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–1 · завершён",
+              "detailsUrl": "https://youtu.be/labubu-team-geeks-28-nov",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
             }
           ]
         }

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -20,17 +20,6 @@
   },
   "matches": [
     {
-      "id": "2025-11-28-labubu-team-geeks",
-      "dayLabel": "Пт 28.11",
-      "timeLabel": "19:00",
-      "dateTime": "2025-11-28T19:00:00+03:00",
-      "teams": {
-        "home": "Labubu Team",
-        "away": "Гики"
-      },
-      "channelIds": ["primary"]
-    },
-    {
       "id": "2025-11-30-tech-titans-team-borisogleb",
       "dayLabel": "Вск 30.11",
       "timeLabel": "15:00",


### PR DESCRIPTION
## Summary
- add the finished Labubu Team vs Гики series to the match results with per-map scores and VOD link
- remove the completed match from the list of upcoming fixtures

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b16f9e5908323bc25bc88d0b518e3)