### PR TITLE
Enhance auth success handling

### DIFF
--- a/src/features/auth/AuthPage.test.jsx
+++ b/src/features/auth/AuthPage.test.jsx
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { AuthContext } from '../../context/AuthContext.jsx';
+import AuthPage from './AuthPage.jsx';
+import KaraokePage from '../karaoke/KaraokePage.jsx';
+
+const renderAuth = (contextValue) =>
+  render(
+    <AuthContext.Provider value={contextValue}>
+      <MemoryRouter initialEntries={['/auth']}>
+        <Routes>
+          <Route path="/auth" element={<AuthPage />} />
+          <Route path="/karaoke" element={<KaraokePage />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>,
+  );
+
+describe('AuthPage', () => {
+  const setToken = vi.fn();
+  const signOut = vi.fn();
+  const baseContext = { token: null, setToken, signOut };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('navigates to karaoke and shows success notice after successful sign in', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ token: 'sample-token' }),
+    });
+
+    renderAuth(baseContext);
+
+    fireEvent.change(screen.getByPlaceholderText('Введите логин'), {
+      target: { value: 'demo' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Введите пароль'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Войти' }));
+
+    await waitFor(() => expect(setToken).toHaveBeenCalledWith('sample-token', { remember: true }));
+
+    expect(await screen.findByText('Вы успешно вошли в систему')).toBeInTheDocument();
+    expect(screen.getByText('Караоке доступно всем')).toBeInTheDocument();
+  });
+
+  it('shows friendly server error and keeps form active', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ message: 'Internal server error' }),
+    });
+
+    renderAuth(baseContext);
+
+    fireEvent.change(screen.getByPlaceholderText('Введите логин'), {
+      target: { value: 'demo' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Введите пароль'), {
+      target: { value: 'secret' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Войти' }));
+
+    expect(
+      await screen.findByText('Internal server error'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Войти' })).toBeEnabled();
+    expect(screen.getByPlaceholderText('Введите логин')).toHaveValue('demo');
+  });
+});

--- a/src/features/karaoke/KaraokePage.css
+++ b/src/features/karaoke/KaraokePage.css
@@ -20,6 +20,17 @@
   text-align: center;
 }
 
+.karaoke-toast {
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(34, 197, 94, 0.1);
+  color: #8ef6d1;
+  border: 1px solid rgba(34, 197, 94, 0.4);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
 .karaoke-title {
   margin: 0 0 12px;
   font-size: 32px;

--- a/src/features/karaoke/KaraokePage.jsx
+++ b/src/features/karaoke/KaraokePage.jsx
@@ -1,22 +1,41 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 
 import './KaraokePage.css';
 
-const KaraokePage = () => (
-  <main className="karaoke-page">
-    <section className="karaoke-card" aria-labelledby="karaoke-title">
-      <h1 id="karaoke-title" className="karaoke-title">
-        Караоке доступно всем
-      </h1>
-      <p className="karaoke-description">
-        Эта страница открыта без авторизации. Просто выберите любимую композицию и
-        наслаждайтесь атмосферой.
-      </p>
-      <Link className="karaoke-link" to="/">
-        Вернуться на главную
-      </Link>
-    </section>
-  </main>
-);
+const KaraokePage = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [authNotice, setAuthNotice] = useState(location.state?.authNotice || '');
+
+  useEffect(() => {
+    if (location.state?.authNotice) {
+      setAuthNotice(location.state.authNotice);
+      navigate(location.pathname, { replace: true });
+    }
+  }, [location.pathname, location.state?.authNotice, navigate]);
+
+  return (
+    <main className="karaoke-page">
+      <section className="karaoke-card" aria-labelledby="karaoke-title">
+        {authNotice ? (
+          <div className="karaoke-toast" role="status" aria-live="polite">
+            {authNotice}
+          </div>
+        ) : null}
+        <h1 id="karaoke-title" className="karaoke-title">
+          Караоке доступно всем
+        </h1>
+        <p className="karaoke-description">
+          Эта страница открыта без авторизации. Просто выберите любимую композицию и
+          наслаждайтесь атмосферой.
+        </p>
+        <Link className="karaoke-link" to="/">
+          Вернуться на главную
+        </Link>
+      </section>
+    </main>
+  );
+};
 
 export default KaraokePage;


### PR DESCRIPTION
## Summary
- redirect users to the karaoke area after successful sign-in and surface a success notice
- improve sign-in error handling with clearer guidance for network and server failures
- add tests covering successful navigation and server error scenarios

## Testing
- npm test
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d77a858208323aeff758c5b5f5f88)