### PR TITLE
feat: add authenticated api client hook

### DIFF
--- a/src/features/auth/AuthPage.jsx
+++ b/src/features/auth/AuthPage.jsx
@@ -1,12 +1,14 @@
 import { useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext.jsx';
+import useApiClient from '../../hooks/useApiClient.js';
 import './AuthPage.css';
 
 const AuthPage = () => {
   const { setToken } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
+  const apiClient = useApiClient();
   const redirectPath = location.state?.from?.pathname || '/karaoke';
   const [login, setLogin] = useState('');
   const [password, setPassword] = useState('');
@@ -25,12 +27,13 @@ const AuthPage = () => {
     setLoading(true);
 
     try {
-      const response = await fetch('/api/auth/sign-in', {
+      const response = await apiClient('/api/auth/sign-in', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ login, password }),
+        skipAuth: true,
       });
 
       const payload = await response.json().catch(() => ({}));

--- a/src/hooks/useApiClient.js
+++ b/src/hooks/useApiClient.js
@@ -1,0 +1,58 @@
+import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { useAuth } from '../context/AuthContext.jsx';
+
+const AUTH_NOTICE_MESSAGE = 'Ваша сессия истекла. Авторизуйтесь снова.';
+
+const toHeaders = (headers) => {
+  if (headers instanceof Headers) {
+    return headers;
+  }
+
+  return new Headers(headers ?? {});
+};
+
+const serializeLocation = (location) => ({
+  pathname: location.pathname,
+  search: location.search,
+  hash: location.hash,
+});
+
+export const useApiClient = () => {
+  const { token, signOut } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  return useCallback(
+    async (input, options = {}) => {
+      const { skipAuth = false, ...fetchOptions } = options;
+      const headers = toHeaders(fetchOptions.headers);
+
+      if (!skipAuth && token) {
+        headers.set('Authorization', `Bearer ${token}`);
+      }
+
+      const response = await fetch(input, {
+        ...fetchOptions,
+        headers,
+      });
+
+      if (response.status === 401 && !skipAuth) {
+        signOut();
+        navigate('/auth', {
+          replace: true,
+          state: {
+            from: serializeLocation(location),
+            authNotice: AUTH_NOTICE_MESSAGE,
+          },
+        });
+      }
+
+      return response;
+    },
+    [location, navigate, signOut, token],
+  );
+};
+
+export default useApiClient;

--- a/src/hooks/useApiClient.test.jsx
+++ b/src/hooks/useApiClient.test.jsx
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 
+import PropTypes from 'prop-types';
+
 import { AuthContext } from '../context/AuthContext.jsx';
 import useApiClient from './useApiClient.js';
 
@@ -16,9 +18,18 @@ vi.mock('react-router-dom', async () => {
   };
 });
 
-const createWrapper = (contextValue) => ({ children }) => (
-  <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>
-);
+const createWrapper = (contextValue) => {
+  const ProviderWrapper = ({ children }) => (
+    <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>
+  );
+
+  ProviderWrapper.displayName = 'ProviderWrapper';
+  ProviderWrapper.propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
+  return ProviderWrapper;
+};
 
 describe('useApiClient', () => {
   beforeEach(() => {

--- a/src/hooks/useApiClient.test.jsx
+++ b/src/hooks/useApiClient.test.jsx
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { AuthContext } from '../context/AuthContext.jsx';
+import useApiClient from './useApiClient.js';
+
+const navigateMock = vi.fn();
+const locationMock = { pathname: '/secure', search: '?q=1', hash: '#top' };
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useLocation: () => locationMock,
+  };
+});
+
+const createWrapper = (contextValue) => ({ children }) => (
+  <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>
+);
+
+describe('useApiClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('adds Authorization header when token is present', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200 });
+    const signOut = vi.fn();
+    const { result } = renderHook(() => useApiClient(), {
+      wrapper: createWrapper({ token: 'token-123', setToken: vi.fn(), signOut }),
+    });
+
+    await result.current('/api/protected', { method: 'GET' });
+
+    const headers = fetch.mock.calls[0][1].headers;
+    expect(headers.get('Authorization')).toBe('Bearer token-123');
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('skips Authorization header when skipAuth is true', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, status: 200 });
+    const signOut = vi.fn();
+    const { result } = renderHook(() => useApiClient(), {
+      wrapper: createWrapper({ token: 'token-123', setToken: vi.fn(), signOut }),
+    });
+
+    await result.current('/api/public', { method: 'GET', skipAuth: true });
+
+    const headers = fetch.mock.calls[0][1].headers;
+    expect(headers.get('Authorization')).toBeNull();
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('signs out and navigates to auth on 401 responses', async () => {
+    fetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    const signOut = vi.fn();
+    const { result } = renderHook(() => useApiClient(), {
+      wrapper: createWrapper({ token: 'expired-token', setToken: vi.fn(), signOut }),
+    });
+
+    const response = await result.current('/api/protected', { method: 'GET' });
+
+    expect(response.status).toBe(401);
+    expect(signOut).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith('/auth', {
+      replace: true,
+      state: {
+        from: locationMock,
+        authNotice: 'Ваша сессия истекла. Авторизуйтесь снова.',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable `useApiClient` hook that injects auth headers and redirects on unauthorized responses
- integrate the new client into the auth flow to centralize request handling
- cover the client with unit tests to validate header injection and 401 handling

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d7c32e4908323ac53e2d8041ed19d)