### PR TITLE
Update match records after Mi ne Pushim! vs Ближайшие

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -551,6 +551,55 @@
               "winner": "away"
             }
           ]
+        },
+        {
+          "id": "week-4",
+          "title": "Неделя 4 · 2–7 декабря",
+          "matches": [
+            {
+              "id": "2025-12-02-mi-ne-pushim-blizhayshie",
+              "dateLabel": "2 дек · 19:00",
+              "dateTime": "2025-12-02T19:00:00+03:00",
+              "stage": "Круг 2",
+              "teams": {
+                "home": "Mi ne Pushim!",
+                "away": "Ближайшие"
+              },
+              "score": {
+                "home": 1,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 36,
+                    "away": 36
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 20,
+                    "away": 36
+                  }
+                },
+                {
+                  "id": "game-3",
+                  "score": {
+                    "home": 26,
+                    "away": 57
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "1–2 · завершён",
+              "detailsUrl": "https://youtu.be/mi-ne-pushim-blizhayshie-02-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            }
+          ]
         }
       ]
     }

--- a/src/features/QualificationsTable/standings.test.js
+++ b/src/features/QualificationsTable/standings.test.js
@@ -21,12 +21,12 @@ test('buildStandingsFromMatchResults aggregates finished matches into standings'
   assert.deepStrictEqual(miNePushim, {
     id: 'mi-ne-pushim',
     name: 'Mi ne Pushim!',
-    matches: 2,
+    matches: 3,
     wins: 1,
-    losses: 1,
-    mapWins: 3,
-    mapLosses: 2,
-    points: 3,
+    losses: 2,
+    mapWins: 4,
+    mapLosses: 4,
+    points: 4,
   });
 
   const uniqueIds = new Set(standings.map((team) => team.id));

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -20,17 +20,6 @@
   },
   "matches": [
     {
-      "id": "2025-12-02-mi-ne-pushim-blizhayshie",
-      "dayLabel": "Вт 2.12",
-      "timeLabel": "19:00",
-      "dateTime": "2025-12-02T19:00:00+03:00",
-      "teams": {
-        "home": "Mi ne Pushim!",
-        "away": "Ближайшие"
-      },
-      "channelIds": ["primary"]
-    },
-    {
       "id": "2025-12-04-arb-esports-japan",
       "dayLabel": "Чт 4.12",
       "timeLabel": "20:00",


### PR DESCRIPTION
## Summary
- remove the completed Mi ne Pushim! vs Ближайшие series from the upcoming matches schedule
- record the 1–2 result with map scores in a new Round 2 Week 4 results section
- refresh standings expectations to account for the additional played series

## Testing
- npm run lint
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fefcf75308323bd4e1f9c2ec14b09)