### PR TITLE
Fix match week and stage details

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -554,13 +554,13 @@
         },
         {
           "id": "week-4",
-          "title": "Неделя 4 · 2–7 декабря",
+          "title": "Неделя 3 · 2–7 декабря",
           "matches": [
             {
               "id": "2025-12-02-mi-ne-pushim-blizhayshie",
               "dateLabel": "2 дек · 19:00",
               "dateTime": "2025-12-02T19:00:00+03:00",
-              "stage": "Круг 2",
+              "stage": "Круг 3",
               "teams": {
                 "home": "Mi ne Pushim!",
                 "away": "Ближайшие"


### PR DESCRIPTION
## Summary
- update Mi ne Pushim! vs Ближайшие matchup to show correct week label
- adjust stage to Круг 3 per schedule information

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff23bc3488323b82796505e7b9089)