### PR TITLE
Move third round match into correct round

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -278,7 +278,7 @@
       "id": "round-2",
       "title": "Результаты 2-го круга",
       "subtitle": "Групповой этап",
-      "defaultExpanded": true,
+      "defaultExpanded": false,
       "weeks": [
         {
           "id": "week-3",
@@ -551,7 +551,15 @@
               "winner": "away"
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "id": "round-3",
+      "title": "Результаты 3-го круга",
+      "subtitle": "Групповой этап",
+      "defaultExpanded": true,
+      "weeks": [
         {
           "id": "week-4",
           "title": "Неделя 3 · 2–7 декабря",


### PR DESCRIPTION
## Summary
- add a dedicated third-round results section and move the Mi ne Pushim! vs Ближайшие match into it
- collapse the second-round accordion by default so the newest third-round results stay highlighted

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff73daaf0832390b9ff6872baa429)