### PR TITLE
Add December 4 match result for ARB ESports vs Japan

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -606,6 +606,42 @@
               "detailsUrl": "https://youtu.be/mi-ne-pushim-blizhayshie-02-dec",
               "detailsLabel": "Смотреть повтор",
               "winner": "away"
+            },
+            {
+              "id": "2025-12-04-arb-esports-japan",
+              "dateLabel": "4 дек · 19:00",
+              "dateTime": "2025-12-04T19:00:00+03:00",
+              "stage": "Круг 3",
+              "teams": {
+                "home": "ARB ESports",
+                "away": "Japan 日本"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 46,
+                    "away": 54
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 8,
+                    "away": 20
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://youtu.be/arb-esports-japan-04-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
             }
           ]
         }


### PR DESCRIPTION
## Summary
- add the December 4 Round 3 matchup between ARB ESports and Japan 日本 with map scores and status labels

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931e5dbbe048323b39aae6bde8aeb91)