### PR TITLE
Update YGK match status

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -642,6 +642,42 @@
               "detailsUrl": "https://youtu.be/arb-esports-japan-04-dec",
               "detailsLabel": "Смотреть повтор",
               "winner": "away"
+            },
+            {
+              "id": "2025-12-05-ygk-buyback-academy",
+              "dateLabel": "5 дек · 19:00",
+              "dateTime": "2025-12-05T19:00:00+03:00",
+              "stage": "Круг 3",
+              "teams": {
+                "home": "YGK",
+                "away": "BuyBack Academy"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 3,
+                    "away": 46
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 14,
+                    "away": 30
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://youtu.be/ygk-buyback-academy-05-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
             }
           ]
         }

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -31,17 +31,6 @@
       "channelIds": ["primary"]
     },
     {
-      "id": "2025-12-05-ygk-buyback-academy",
-      "dayLabel": "Пт 5.12",
-      "timeLabel": "19:00",
-      "dateTime": "2025-12-05T19:00:00+03:00",
-      "teams": {
-        "home": "YGK",
-        "away": "BuyBack Academy"
-      },
-      "channelIds": ["primary"]
-    },
-    {
       "id": "2025-12-05-geeks-ne-znayushchie-pobed",
       "dayLabel": "Сб 6.12",
       "timeLabel": "19:00",


### PR DESCRIPTION
## Summary
- remove the YGK vs BuyBack Academy pairing from upcoming matches
- record the YGK vs BuyBack Academy result with map scores in the finished matches list

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69331dac99188323bdd270259a86972b)