### PR TITLE
Fix match results config JSON structure

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -650,7 +650,7 @@
               "stage": "Круг 3",
               "teams": {
                 "home": "YGK",
-                "away": "BuyBack Academy"
+                "away": "Buyback Academy"
               },
               "score": {
                 "home": 0,

--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -644,7 +644,7 @@
               "winner": "away"
             },
             {
-             "id": "2025-12-05-ygk-buyback-academy",
+              "id": "2025-12-05-ygk-buyback-academy",
               "dateLabel": "5 дек · 19:00",
               "dateTime": "2025-12-05T19:00:00+03:00",
               "stage": "Круг 3",
@@ -677,9 +677,8 @@
               "statusLabel": "0–2 · завершён",
               "detailsUrl": "https://youtu.be/arb-esports-japan-04-dec",
               "detailsLabel": "Смотреть повтор",
-              "winner": "away" 
-             }
-          }
+              "winner": "away"
+            }
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- correct the 2025-12-05 YGK vs Buyback Academy entry so the matches array closes properly
- tidy indentation around the corrected match entry to keep config.json valid

## Testing
- unable to run npm test (missing npm/node runtime in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933259581fc8323bfd5b094aad4ba84)