### PR TITLE
Update Borisogleb vs Steel Titans result

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -678,6 +678,42 @@
               "detailsUrl": "https://youtu.be/arb-esports-japan-04-dec",
               "detailsLabel": "Смотреть повтор",
               "winner": "away"
+            },
+            {
+              "id": "2025-12-06-team-borisogleb-steel-titans",
+              "dateLabel": "6 дек · 15:00",
+              "dateTime": "2025-12-06T15:00:00+03:00",
+              "stage": "Круг 3",
+              "teams": {
+                "home": "Team Borisogleb",
+                "away": "Steel Titans"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 35,
+                    "away": 32
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 35,
+                    "away": 14
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://youtu.be/team-borisogleb-steel-titans-06-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
             }
           ]
         }

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -31,17 +31,6 @@
       "channelIds": ["secondary"]
     },
     {
-      "id": "2025-12-06-team-borisogleb-steel-titans",
-      "dayLabel": "Сб 6.12",
-      "timeLabel": "15:00",
-      "dateTime": "2025-12-06T15:00:00+03:00",
-      "teams": {
-        "home": "Team Borisogleb",
-        "away": "Steel Titans"
-      },
-      "channelIds": ["primary"]
-    },
-    {
       "id": "2025-12-07-tech-titans-way-prod",
       "dayLabel": "Вск 7.12",
       "timeLabel": "15:00",


### PR DESCRIPTION
## Summary
- remove the completed Team Borisogleb vs Steel Titans matchup from the upcoming schedule
- add the finished Borisogleb vs Steel Titans series with map scores to the latest results

## Testing
- npm run lint *(warning: pre-existing React hook dependency warning in src/hooks/useApiClient.js)*
- npm test --silent *(hangs with Vitest repeating 0 tests; run was interrupted after ~35s)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343f423d888323a269f57da7d8d180)