### PR TITLE
Update round 3 match results

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -750,6 +750,78 @@
               "detailsUrl": "https://youtu.be/geeks-ne-znayushchie-pobed-06-dec",
               "detailsLabel": "Смотреть повтор",
               "winner": "home"
+            },
+            {
+              "id": "2025-12-07-tech-titans-way-prod",
+              "dateLabel": "7 дек · 17:00",
+              "dateTime": "2025-12-07T17:00:00+03:00",
+              "stage": "Круг 3",
+              "teams": {
+                "home": "Tech Titans",
+                "away": "Way Prod."
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 13,
+                    "away": 37
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 12,
+                    "away": 29
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://youtu.be/tech-titans-way-prod-07-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2025-12-07-labubu-yellow-submarine",
+              "dateLabel": "7 дек · 19:00",
+              "dateTime": "2025-12-07T19:00:00+03:00",
+              "stage": "Круг 3",
+              "teams": {
+                "home": "Labubu Team",
+                "away": "Yellow Submarine"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 3,
+                    "away": 17
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 8,
+                    "away": 32
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://youtu.be/labubu-team-yellow-submarine-07-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
             }
           ]
         }

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -18,28 +18,5 @@
       "url": "https://www.twitch.tv/yarcyberseason3"
     }
   },
-  "matches": [
-    {
-      "id": "2025-12-07-tech-titans-way-prod",
-      "dayLabel": "Вск 7.12",
-      "timeLabel": "17:00",
-      "dateTime": "2025-12-07T17:00:00+03:00",
-      "teams": {
-        "home": "Tech Titans",
-        "away": "Way Prod."
-      },
-      "channelIds": ["primary"]
-    },
-    {
-      "id": "2025-12-07-labubu-yellow-submarine",
-      "dayLabel": "Вск 7.12",
-      "timeLabel": "19:00",
-      "dateTime": "2025-12-07T19:00:00+03:00",
-      "teams": {
-        "home": "Labubu Team",
-        "away": "Yellow Submarine"
-      },
-      "channelIds": ["primary"]
-    }
-  ]
+  "matches": []
 }


### PR DESCRIPTION
## Summary
- remove completed December 7 fixtures from the upcoming matches list
- add round 3 results for Tech Titans vs Way Prod and Labubu Team vs Yellow Submarine with map scores and links

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c1b865f88323ba7e00da8ea8271c)