### PR TITLE
Add round 4 match result and update schedules

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -826,6 +826,56 @@
           ]
         }
       ]
+    },
+    {
+      "id": "round-4",
+      "title": "Результаты 4-го круга",
+      "subtitle": "Групповой этап",
+      "defaultExpanded": true,
+      "weeks": [
+        {
+          "id": "week-5",
+          "title": "Неделя 4 · 9–15 декабря",
+          "matches": [
+            {
+              "id": "2025-12-09-team-borisogleb-mi-ne-pushim",
+              "dateLabel": "9 дек · 21:00",
+              "dateTime": "2025-12-09T21:00:00+03:00",
+              "stage": "Круг 4",
+              "teams": {
+                "home": "Team Borisogleb",
+                "away": "Mi ne Pushim!"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 52,
+                    "away": 55
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 44,
+                    "away": 49
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://youtu.be/team-borisogleb-mi-ne-pushim-09-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/features/QualificationsTable/standings.test.js
+++ b/src/features/QualificationsTable/standings.test.js
@@ -21,12 +21,12 @@ test('buildStandingsFromMatchResults aggregates finished matches into standings'
   assert.deepStrictEqual(miNePushim, {
     id: 'mi-ne-pushim',
     name: 'Mi ne Pushim!',
-    matches: 3,
-    wins: 1,
+    matches: 4,
+    wins: 2,
     losses: 2,
-    mapWins: 4,
+    mapWins: 6,
     mapLosses: 4,
-    points: 4,
+    points: 6,
   });
 
   const uniqueIds = new Set(standings.map((team) => team.id));

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -20,17 +20,6 @@
   },
   "matches": [
     {
-      "id": "2025-12-09-team-borisogleb-mi-ne-pushim",
-      "dayLabel": "Вт · 9 декабря",
-      "timeLabel": "21:00",
-      "dateTime": "2025-12-09T21:00:00+03:00",
-      "teams": {
-        "home": "Team Borisogleb",
-        "away": "Mi ne Pushim!"
-      },
-      "channelIds": ["primary"]
-    },
-    {
       "id": "2025-12-10-steel-titans-buyback-academy",
       "dayLabel": "Ср · 10 декабря",
       "timeLabel": "19:00",


### PR DESCRIPTION
## Summary
- remove the completed 9 December match from upcoming fixtures
- add a new Round 4 results block with Mi ne Pushim! vs Team Borisogleb and map scores
- refresh standings test expectations after the additional match data

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69389a6f0be483238e19d74a7ebac769)