### PR TITLE
feat: add Steel Titans vs Buyback result

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -872,6 +872,49 @@
               "detailsUrl": "https://youtu.be/team-borisogleb-mi-ne-pushim-09-dec",
               "detailsLabel": "Смотреть повтор",
               "winner": "away"
+            },
+            {
+              "id": "2025-12-10-steel-titans-buyback-academy",
+              "dateLabel": "10 дек · 19:00",
+              "dateTime": "2025-12-10T19:00:00+03:00",
+              "stage": "Круг 4",
+              "teams": {
+                "home": "Steel Titans",
+                "away": "Buyback Academy"
+              },
+              "score": {
+                "home": 2,
+                "away": 1
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 44,
+                    "away": 32
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 33,
+                    "away": 45
+                  }
+                },
+                {
+                  "id": "game-3",
+                  "score": {
+                    "home": 45,
+                    "away": 19
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–1 · завершён",
+              "detailsUrl": "https://youtu.be/steel-titans-buyback-academy-10-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
             }
           ]
         }

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -20,17 +20,6 @@
   },
   "matches": [
     {
-      "id": "2025-12-10-steel-titans-buyback-academy",
-      "dayLabel": "Ср · 10 декабря",
-      "timeLabel": "19:00",
-      "dateTime": "2025-12-10T19:00:00+03:00",
-      "teams": {
-        "home": "Steel Titans",
-        "away": "Buyback Academy"
-      },
-      "channelIds": ["primary"]
-    },
-    {
       "id": "2025-12-11-ygk-giki",
       "dayLabel": "Чт · 11 декабря",
       "timeLabel": "19:30",


### PR DESCRIPTION
## Summary
- add completed Steel Titans vs Buyback Academy match with map scores
- remove the finished fixture from the upcoming schedule

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939d18f6c888323b2d6c2083724bd68)