### PR TITLE
Update match results and apply point deductions

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -915,6 +915,78 @@
               "detailsUrl": "https://youtu.be/steel-titans-buyback-academy-10-dec",
               "detailsLabel": "Смотреть повтор",
               "winner": "home"
+            },
+            {
+              "id": "2025-12-11-geeks-ygk",
+              "dateLabel": "11 дек · 19:30",
+              "dateTime": "2025-12-11T19:30:00+03:00",
+              "stage": "Круг 4",
+              "teams": {
+                "home": "Гики",
+                "away": "YGK"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 51,
+                    "away": 30
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 66,
+                    "away": 50
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://youtu.be/geeks-ygk-11-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2025-12-11-tech-titans-arb-esports",
+              "dateLabel": "11 дек · 19:30",
+              "dateTime": "2025-12-11T19:30:00+03:00",
+              "stage": "Круг 4",
+              "teams": {
+                "home": "Tech Titans",
+                "away": "ARB ESports"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 34,
+                    "away": 31
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 10,
+                    "away": 5
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://youtu.be/tech-titans-arb-esports-11-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
             }
           ]
         }

--- a/src/features/QualificationsTable/standings.js
+++ b/src/features/QualificationsTable/standings.js
@@ -21,6 +21,25 @@ const ensureTeam = (teamsMap, name) => {
 
 const toNumber = (value) => (Number.isFinite(value) ? value : 0);
 
+const POINT_DEDUCTIONS = {
+  'Не Знающие Побед': 6,
+  'Labubu Team': 6,
+};
+
+const applyPointDeductions = (teams, deductions) =>
+  teams.map((team) => {
+    const deduction = deductions[team.name];
+
+    if (!deduction) {
+      return team;
+    }
+
+    return {
+      ...team,
+      points: team.points - deduction,
+    };
+  });
+
 export const extractFinishedMatchesByWeek = (matchResults) =>
   (matchResults?.rounds ?? [])
     .flatMap((round) => round?.weeks ?? [])
@@ -72,7 +91,9 @@ export const buildStandingsFromMatches = (finishedMatches) => {
     awayTeam.points += awayMaps;
   });
 
-  return Array.from(teamsMap.values());
+  const teams = Array.from(teamsMap.values());
+
+  return applyPointDeductions(teams, POINT_DEDUCTIONS);
 };
 
 export const buildStandingsFromMatchResults = (matchResults) =>

--- a/src/features/QualificationsTable/standings.test.js
+++ b/src/features/QualificationsTable/standings.test.js
@@ -43,6 +43,19 @@ test('buildStandingsFromMatches aggregates matches for a single week', () => {
   assert.strictEqual(firstTeam.matches, 1);
 });
 
+test('buildStandingsFromMatchResults applies point deductions for penalized teams', () => {
+  const standings = buildStandingsFromMatchResults(matchResultsConfig);
+
+  const penalizedTeam = standings.find((team) => team.name === 'Не Знающие Побед');
+  const labubuTeam = standings.find((team) => team.name === 'Labubu Team');
+
+  assert.ok(penalizedTeam, 'Penalized team should exist in standings');
+  assert.strictEqual(penalizedTeam.points, penalizedTeam.mapWins - 6);
+
+  assert.ok(labubuTeam, 'Labubu Team should exist in standings');
+  assert.strictEqual(labubuTeam.points, labubuTeam.mapWins - 6);
+});
+
 test('sortTeams orders by points, map difference, map wins, then alphabetically', () => {
   const teams = [
     { id: 'c', name: 'Team C', matches: 1, wins: 1, losses: 0, mapWins: 2, mapLosses: 0, points: 3 },

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -20,28 +20,6 @@
   },
   "matches": [
     {
-      "id": "2025-12-11-ygk-giki",
-      "dayLabel": "Чт · 11 декабря",
-      "timeLabel": "19:30",
-      "dateTime": "2025-12-11T19:30:00+03:00",
-      "teams": {
-        "home": "YGK",
-        "away": "Гики"
-      },
-      "channelIds": ["secondary"]
-    },
-    {
-      "id": "2025-12-11-tech-titans-arb-esports",
-      "dayLabel": "Чт · 11 декабря",
-      "timeLabel": "19:30",
-      "dateTime": "2025-12-11T19:30:00+03:00",
-      "teams": {
-        "home": "Tech Titans",
-        "away": "ARB ESports"
-      },
-      "channelIds": ["primary"]
-    },
-    {
       "id": "2025-12-12-yellow-submarine-blyzhayshie",
       "dayLabel": "Пт · 12 декабря",
       "timeLabel": "19:00",


### PR DESCRIPTION
## Summary
- remove the completed YGK vs Гики and Tech Titans vs ARB ESports fixtures from upcoming matches and record their results
- add 6-point deductions for Labubu Team and Не Знающие Побед in the standings calculation
- cover the new point penalty logic with automated tests

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b2f08844083238ab616baf7444f11)