### PR TITLE
Move Yellow Submarine vs Ближайшие match to results

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -987,6 +987,42 @@
               "detailsUrl": "https://youtu.be/tech-titans-arb-esports-11-dec",
               "detailsLabel": "Смотреть повтор",
               "winner": "home"
+            },
+            {
+              "id": "2025-12-12-yellow-submarine-blizhayshie",
+              "dateLabel": "12 дек · 19:00",
+              "dateTime": "2025-12-12T19:00:00+03:00",
+              "stage": "Круг 4",
+              "teams": {
+                "home": "Yellow Submarine",
+                "away": "Ближайшие"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 9,
+                    "away": 31
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 18,
+                    "away": 50
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://youtu.be/yellow-submarine-blizhayshie-12-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
             }
           ]
         }

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -20,17 +20,6 @@
   },
   "matches": [
     {
-      "id": "2025-12-12-yellow-submarine-blyzhayshie",
-      "dayLabel": "Пт · 12 декабря",
-      "timeLabel": "19:00",
-      "dateTime": "2025-12-12T19:00:00+03:00",
-      "teams": {
-        "home": "Yellow Submarine",
-        "away": "Ближайшие"
-      },
-      "channelIds": ["primary"]
-    },
-    {
       "id": "2025-12-14-japan-way-prod",
       "dayLabel": "Вс · 14 декабря",
       "timeLabel": "19:00",


### PR DESCRIPTION
## Summary
- remove the finished Yellow Submarine vs Ближайшие fixture from the upcoming schedule
- add the completed 2:0 result with map scores to the round 4 results list

## Testing
- npm run lint *(warning about existing missing dependency in useApiClient hook)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c5c3f9fc48323aade2ac12fdd40e7)