### PR TITLE
Update Japan vs Way Prod match result

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -1023,6 +1023,42 @@
               "detailsUrl": "https://youtu.be/yellow-submarine-blizhayshie-12-dec",
               "detailsLabel": "Смотреть повтор",
               "winner": "away"
+            },
+            {
+              "id": "2025-12-14-japan-way-prod",
+              "dateLabel": "14 дек · 19:00",
+              "dateTime": "2025-12-14T19:00:00+03:00",
+              "stage": "Круг 4",
+              "teams": {
+                "home": "Japan 日本",
+                "away": "Way Prod."
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 28,
+                    "away": 50
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 30,
+                    "away": 35
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://youtu.be/japan-way-prod-14-dec",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
             }
           ]
         }

--- a/src/features/UpcomingMatches/config.json
+++ b/src/features/UpcomingMatches/config.json
@@ -18,17 +18,5 @@
       "url": "https://www.twitch.tv/yarcyberseason3"
     }
   },
-  "matches": [
-    {
-      "id": "2025-12-14-japan-way-prod",
-      "dayLabel": "Вс · 14 декабря",
-      "timeLabel": "19:00",
-      "dateTime": "2025-12-14T19:00:00+03:00",
-      "teams": {
-        "home": "Japan 日本",
-        "away": "Way Prod."
-      },
-      "channelIds": ["primary"]
-    }
-  ]
+  "matches": []
 }


### PR DESCRIPTION
## Summary
- remove the Japan vs Way Prod pairing from the upcoming matches schedule
- add the finished Japan vs Way Prod match to round 4 results with a 2–0 score and map breakdown

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693fc00ef1b48323b842e66a7d152c0e)