### PR TITLE
chore: remove unused karaoke endpoint env vars and simplify API endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,3 @@ VITE_API_BASE_URL=https://api.aik.bar
 
 # Authentication and karaoke task endpoints
 VITE_SIGN_IN_ENDPOINT=/api/auth/sign-in
-VITE_JOB_STATUS_ENDPOINT=/api/karaoke-tracks/tasks
-VITE_CREATE_TASK_URL=/api/karaoke-tracks/create-task-from-url
-VITE_CREATE_TASK_FILE=/api/karaoke-tracks/create-task-from-file

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ VITE_API_BASE_URL=http://localhost:3000
 
 # REST endpoints (override if your backend uses custom paths)
 VITE_SIGN_IN_ENDPOINT=/api/auth/sign-in
-VITE_JOB_STATUS_ENDPOINT=/api/karaoke-tracks/tasks
-VITE_CREATE_TASK_URL=/api/karaoke-tracks/create-task-from-url
-VITE_CREATE_TASK_FILE=/api/karaoke-tracks/create-task-from-file
 ```
 
 ## Available Scripts

--- a/src/config/apiEndpoints.js
+++ b/src/config/apiEndpoints.js
@@ -1,17 +1,11 @@
 const DEFAULT_ENDPOINTS = {
   SIGN_IN: '/api/auth/sign-in',
-  JOB_STATUS: '/api/karaoke-tracks/tasks',
-  CREATE_TASK_FROM_URL: '/api/karaoke-tracks/create-task-from-url',
-  CREATE_TASK_FROM_FILE: '/api/karaoke-tracks/create-task-from-file',
 };
 
 const hasValue = (value) => value !== undefined && value !== null && value !== 'undefined';
 
 const ENV_KEYS = {
   SIGN_IN: 'VITE_SIGN_IN_ENDPOINT',
-  JOB_STATUS: 'VITE_JOB_STATUS_ENDPOINT',
-  CREATE_TASK_FROM_URL: 'VITE_CREATE_TASK_URL',
-  CREATE_TASK_FROM_FILE: 'VITE_CREATE_TASK_FILE',
 };
 
 export const getApiEndpoint = (key) => {
@@ -24,15 +18,6 @@ export const getApiEndpoint = (key) => {
 export const API_ENDPOINTS = {
   get SIGN_IN() {
     return getApiEndpoint('SIGN_IN');
-  },
-  get JOB_STATUS() {
-    return getApiEndpoint('JOB_STATUS');
-  },
-  get CREATE_TASK_FROM_URL() {
-    return getApiEndpoint('CREATE_TASK_FROM_URL');
-  },
-  get CREATE_TASK_FROM_FILE() {
-    return getApiEndpoint('CREATE_TASK_FROM_FILE');
   },
 };
 


### PR DESCRIPTION
### Motivation
- Remove unused karaoke-related endpoint keys and environment variables so runtime configuration and documentation match actual application usage.
- Keep the public env example and README minimal and focused on the endpoints the app actually uses.

### Description
- Simplified `src/config/apiEndpoints.js` to retain only the `SIGN_IN` endpoint and removed `JOB_STATUS` / `CREATE_TASK_FROM_URL` / `CREATE_TASK_FROM_FILE` keys and their env mappings.
- Removed `VITE_JOB_STATUS_ENDPOINT`, `VITE_CREATE_TASK_URL`, and `VITE_CREATE_TASK_FILE` from `.env.example`.
- Removed the same karaoke endpoint variables from the README env block so documentation reflects current behavior.
- Verified that `AuthPage` continues to use `API_ENDPOINTS.SIGN_IN` and that the `VITE_SIGN_IN_ENDPOINT` override is still supported by tests.

### Testing
- Ran `npm test` and all tests passed (6 test files, 22 tests total).
- Ran `npm run lint` which completed successfully with one preexisting warning `react-hooks/exhaustive-deps` in `src/hooks/useApiClient.js` unrelated to these changes.
- Performed a code search to confirm the removed env vars and endpoint keys are no longer referenced in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988431278588327a53318d589df1b1e)