### PR TITLE
feat: переместить галерею ростеров в надблоки Dota 2 и Counter Strike 2

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import sponsorsConfig from './features/Sponsors/config.json';
 import socialLinksConfig from './features/SocialLinks/config.json';
 import QualificationsTable from './features/QualificationsTable/QualificationsTable.jsx';
 import qualificationsConfig from './features/QualificationsTable/config.json';
+import GameDisciplineSection from './components/GameDisciplineSection.jsx';
 import logoImage from './brand-logo.png';
 import './App.css';
 
@@ -27,97 +28,6 @@ const App = () => {
     // Здесь мог бы быть вызов API или интеграция с сервисом отправки.
     console.log('Sponsor form submitted', formData);
   }, []);
-
-  const sections = [
-    {
-      id: 'hero',
-      component: <Hero data={heroConfig} disableVideoOnMobile={heroConfig.media?.disableOnMobile} />,
-      variant: 'hero',
-      hideTitle: true,
-      fullBleed: true,
-      navLabel: 'Главная',
-    },
-    {
-      id: 'overview',
-      title: 'Обзор YarCyberSeason',
-      component: <Overview data={overviewConfig} />,
-      navLabel: 'Обзор',
-      variant: 'overview',
-      background: (
-        <div className="overview-background">
-          <div className="overview-background__blur overview-background__blur--primary" />
-          <div className="overview-background__blur overview-background__blur--secondary" />
-          <div className="overview-background__grain" />
-        </div>
-      ),
-    },
-    {
-      id: 'team-showcase',
-      title: 'Команды сезона',
-      component: <TeamShowcase />,
-      navLabel: 'Команды',
-      variant: 'team-showcase',
-      hideTitle: true,
-    },
-    {
-      id: 'upcoming-matches',
-      component: <UpcomingMatches data={upcomingMatchesConfig} />,
-      navLabel: 'Матчи',
-      variant: 'upcoming-matches',
-      hideTitle: true,
-    },
-    {
-      id: 'qualifications',
-      component: (
-        <QualificationsTable data={qualificationsConfig} matchResults={matchResultsConfig} />
-      ),
-      navLabel: 'Таблица',
-      variant: 'qualifications-table',
-      hideTitle: true,
-      fullBleed: true,
-    },
-    {
-      id: 'match-results',
-      component: <MatchResults data={matchResultsConfig} />,
-      navLabel: 'Результаты',
-      variant: 'match-results',
-      hideTitle: true,
-    },
-    {
-      id: 'registration',
-      component: <RegistrationCta data={registrationCtaConfig} />,
-      navLabel: 'Регистрация',
-      variant: 'registration-cta',
-      hideTitle: true,
-    },
-    {
-      id: 'social',
-      title: 'Социальные каналы',
-      component: <SocialLinks data={socialLinksConfig} />,
-      navLabel: 'Соцсети',
-      variant: 'social-links',
-      hideTitle: true,
-    },
-    {
-      id: 'sponsors',
-      title: 'Партнёры и спонсоры',
-      component: (
-        <Sponsors
-          data={sponsorsConfig}
-          onSponsorFormSubmit={handleSponsorFormSubmit}
-        />
-      ),
-      navLabel: 'Партнёры',
-      variant: 'sponsors',
-    },
-  ];
-
-  const navigationItems = sections
-    .filter((section) => Boolean(section.navLabel))
-    .map((section) => ({
-      id: section.id,
-      label: section.navLabel,
-    }));
 
   const THEME_STORAGE_KEY = 'ycs-theme';
 
@@ -131,6 +41,7 @@ const App = () => {
 
   const [theme, setTheme] = useState(getInitialTheme);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [expandedGameBlocks, setExpandedGameBlocks] = useState({ dota2: false, cs2: true });
 
   useEffect(() => {
     const handleResize = () => {
@@ -170,6 +81,115 @@ const App = () => {
   const handleThemeToggle = () => {
     setTheme((prevTheme) => (prevTheme === 'feminine' ? 'default' : 'feminine'));
   };
+
+  const toggleGameBlock = (blockId) => {
+    setExpandedGameBlocks((prevState) => ({
+      ...prevState,
+      [blockId]: !prevState[blockId],
+    }));
+  };
+
+  const sections = [
+    {
+      id: 'hero',
+      component: <Hero data={heroConfig} disableVideoOnMobile={heroConfig.media?.disableOnMobile} />,
+      variant: 'hero',
+      hideTitle: true,
+      fullBleed: true,
+      navLabel: 'Главная',
+    },
+    {
+      id: 'overview',
+      title: 'Обзор YarCyberSeason',
+      component: <Overview data={overviewConfig} />,
+      navLabel: 'Обзор',
+      variant: 'overview',
+      background: (
+        <div className="overview-background">
+          <div className="overview-background__blur overview-background__blur--primary" />
+          <div className="overview-background__blur overview-background__blur--secondary" />
+          <div className="overview-background__grain" />
+        </div>
+      ),
+    },
+    {
+      id: 'upcoming-matches',
+      component: <UpcomingMatches data={upcomingMatchesConfig} />,
+      navLabel: 'Матчи',
+      variant: 'upcoming-matches',
+      hideTitle: true,
+    },
+    {
+      id: 'dota-2',
+      component: (
+        <GameDisciplineSection
+          id="dota-2"
+          title="Dota 2"
+          isExpanded={expandedGameBlocks.dota2}
+          onToggle={() => toggleGameBlock('dota2')}
+        >
+          <TeamShowcase />
+          <QualificationsTable data={qualificationsConfig} matchResults={matchResultsConfig} />
+          <MatchResults data={matchResultsConfig} />
+        </GameDisciplineSection>
+      ),
+      navLabel: 'Dota 2',
+      variant: 'game-discipline',
+      hideTitle: true,
+      fullBleed: true,
+    },
+    {
+      id: 'counter-strike-2',
+      component: (
+        <GameDisciplineSection
+          id="counter-strike-2"
+          title="Counter Strike 2"
+          isExpanded={expandedGameBlocks.cs2}
+          onToggle={() => toggleGameBlock('cs2')}
+        >
+          <TeamShowcase />
+        </GameDisciplineSection>
+      ),
+      navLabel: 'Counter Strike 2',
+      variant: 'game-discipline',
+      hideTitle: true,
+      fullBleed: true,
+    },
+    {
+      id: 'registration',
+      component: <RegistrationCta data={registrationCtaConfig} />,
+      navLabel: 'Регистрация',
+      variant: 'registration-cta',
+      hideTitle: true,
+    },
+    {
+      id: 'social',
+      title: 'Социальные каналы',
+      component: <SocialLinks data={socialLinksConfig} />,
+      navLabel: 'Соцсети',
+      variant: 'social-links',
+      hideTitle: true,
+    },
+    {
+      id: 'sponsors',
+      title: 'Партнёры и спонсоры',
+      component: (
+        <Sponsors
+          data={sponsorsConfig}
+          onSponsorFormSubmit={handleSponsorFormSubmit}
+        />
+      ),
+      navLabel: 'Партнёры',
+      variant: 'sponsors',
+    },
+  ];
+
+  const navigationItems = sections
+    .filter((section) => Boolean(section.navLabel))
+    .map((section) => ({
+      id: section.id,
+      label: section.navLabel,
+    }));
 
   const isFeminineTheme = theme === 'feminine';
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import App from './App.jsx';
+
+describe('App game discipline blocks', () => {
+  it('renders Dota 2 collapsed and Counter Strike 2 expanded by default', () => {
+    render(<App />);
+
+    const dotaToggle = screen.getAllByRole('button', { name: /Развернуть|Свернуть/ })
+      .find((button) => button.getAttribute('aria-controls') === 'dota-2-content');
+
+    expect(dotaToggle).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Dota 2' })).toBeInTheDocument();
+    expect(document.getElementById('dota-2-content')).toHaveAttribute('hidden');
+
+    expect(screen.getByRole('heading', { name: 'Counter Strike 2' })).toBeInTheDocument();
+    expect(document.getElementById('counter-strike-2-content')).not.toHaveAttribute('hidden');
+  });
+
+  it('toggles game discipline blocks independently', () => {
+    render(<App />);
+
+    const toggles = screen.getAllByRole('button', { name: /Развернуть|Свернуть/ });
+    const dotaToggle = toggles.find((button) => button.getAttribute('aria-controls') === 'dota-2-content');
+    const cs2Toggle = toggles.find((button) => button.getAttribute('aria-controls') === 'counter-strike-2-content');
+
+    fireEvent.click(dotaToggle);
+    expect(document.getElementById('dota-2-content')).not.toHaveAttribute('hidden');
+
+    fireEvent.click(cs2Toggle);
+    expect(document.getElementById('counter-strike-2-content')).toHaveAttribute('hidden');
+  });
+
+  it('shows roster gallery inside both game blocks', () => {
+    render(<App />);
+
+    const toggles = screen.getAllByRole('button', { name: /Развернуть|Свернуть/ });
+    const dotaToggle = toggles.find((button) => button.getAttribute('aria-controls') === 'dota-2-content');
+    fireEvent.click(dotaToggle);
+
+    const galleries = screen.getAllByRole('heading', { name: 'Галерея ростеров' });
+    expect(galleries).toHaveLength(2);
+  });
+});

--- a/src/components/GameDisciplineSection.css
+++ b/src/components/GameDisciplineSection.css
@@ -1,0 +1,57 @@
+.game-discipline {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(145deg, rgba(20, 28, 54, 0.88), rgba(13, 18, 38, 0.95));
+  box-shadow: var(--shadow-soft-elevated);
+  padding: clamp(var(--space-4), 3vw, var(--space-6));
+}
+
+.game-discipline__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.game-discipline__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 1.1rem + 1vw, 2rem);
+  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.game-discipline__toggle {
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--color-text-primary);
+  border-radius: 999px;
+  padding: 0.5rem 0.95rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+.game-discipline__toggle:hover,
+.game-discipline__toggle:focus-visible {
+  background: var(--color-primary-soft);
+}
+
+.game-discipline__content {
+  margin-top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.game-discipline__placeholder {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 1rem;
+}
+
+@media (max-width: 768px) {
+  .game-discipline__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/components/GameDisciplineSection.jsx
+++ b/src/components/GameDisciplineSection.jsx
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+
+import './GameDisciplineSection.css';
+
+const GameDisciplineSection = ({ id, title, isExpanded, onToggle, children }) => {
+  const contentId = `${id}-content`;
+
+  return (
+    <article className="game-discipline" aria-labelledby={`${id}-title`}>
+      <div className="game-discipline__header">
+        <h3 id={`${id}-title`} className="game-discipline__title">{title}</h3>
+        <button
+          type="button"
+          className="game-discipline__toggle"
+          onClick={onToggle}
+          aria-expanded={isExpanded}
+          aria-controls={contentId}
+        >
+          {isExpanded ? 'Свернуть' : 'Развернуть'}
+        </button>
+      </div>
+      <div
+        id={contentId}
+        className={`game-discipline__content${isExpanded ? ' game-discipline__content--expanded' : ''}`}
+        hidden={!isExpanded}
+      >
+        {children}
+      </div>
+    </article>
+  );
+};
+
+GameDisciplineSection.propTypes = {
+  id: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  isExpanded: PropTypes.bool.isRequired,
+  onToggle: PropTypes.func.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default GameDisciplineSection;


### PR DESCRIPTION
### Motivation
- Объединить контент по дисциплинам и сделать галерею ростеров доступной прямо внутри игровых надблоков Dota 2 и Counter Strike 2 вместо отдельной секции для повышенной связности контента. 
- Сохранить доступность и независимое раскрытие блоков дисциплин (aria-атрибуты и `hidden`) при изменении структуры страницы.

### Description
- Добавлен переиспользуемый компонент `GameDisciplineSection` (`src/components/GameDisciplineSection.jsx` + `src/components/GameDisciplineSection.css`) с доступной кнопкой открытия/закрытия (`aria-expanded`, `aria-controls`, `aria-labelledby`) и контейнером контента, скрываемым через `hidden`.
- В `src/App.jsx` удалена отдельная секция `Команды` и `TeamShowcase` перенесён внутрь надблоков: перед таблицей/результатами в `Dota 2` и в каркас `Counter Strike 2` вместо заглушки, также использована существующая логика состояния `expandedGameBlocks` для независимого управления раскрытием.
- Добавлены/обновлены тесты `src/App.test.jsx` — проверка начальных состояний раскрытий, независимого переключения и наличия двух галерей ростеров после раскрытия `Dota 2`.
- Приложены скриншоты страницы до/после изменения (артефакты: `artifacts/before_roster.png`, `artifacts/after_roster.png`).

### Testing
- Запущено `npm run lint` — успешно; линтер не вернул ошибок.
- Запущено `npm run test` — все тесты прошли успешно (всего 18 тестов, все зелёные), включая новый файл `src/App.test.jsx` (3 теста) и существующие модульные тесты; при прогоне появились предупреждения о `defaultProps` (информационные, не фатальные).
- Запущено `npm run build` — сборка прошла успешно.
- Запущено `npm run typecheck` — скрипт отсутствует в `package.json`, поэтому проверка типов не выполнялась.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988541d4e488327b6afb9134fbe24ed)