### PR TITLE
fix(ui): переместить переключатель дисциплин внутрь общего блока

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -276,7 +276,6 @@ main.app {
 }
 
 .game-disciplines-switcher {
-  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
@@ -286,7 +285,6 @@ main.app {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding-right: clamp(9rem, 20vw, 12rem);
 }
 
 .game-disciplines-switcher__title {
@@ -298,10 +296,8 @@ main.app {
 }
 
 .game-disciplines-switcher__controls {
-  position: absolute;
-  top: 0;
-  right: 0;
   display: inline-flex;
+  flex-shrink: 0;
   padding: 0.2rem;
   border-radius: 999px;
   border: 1px solid var(--color-border);


### PR DESCRIPTION
### Motivation
- Переместить визуальный переключатель Dota2/CS2 внутрь общего контейнера секции, чтобы он не «вылезал» за пределы блока.

### Description
- Изменён CSS в `src/App.css`: удалено `position: relative` у `.game-disciplines-switcher`, удалён `padding-right` у `.game-disciplines-switcher__header`, убрано абсолютное позиционирование у `.game-disciplines-switcher__controls` и добавлен `flex-shrink: 0`.

### Testing
- Запущены `npm run lint`, `npm run test` (все тесты пройдены: 20 passed), `npm run build` (успешно) и `npm run lint:assets` (успешно).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b3401422c8327a9c36776c391059c)