### PR TITLE
fix(cs2-bracket): вынести финал нижней сетки в отдельный блок и переименовать матч

### DIFF
--- a/src/features/Cs2Bracket/Cs2Bracket.jsx
+++ b/src/features/Cs2Bracket/Cs2Bracket.jsx
@@ -63,7 +63,7 @@ const Cs2Bracket = ({ matchResults }) => {
         <MatchColumn title="Lower Bracket · раунд 1" matches={bracket.lowerRound1} />
         <MatchColumn title="Lower Bracket · раунд 2" matches={bracket.lowerRound2} />
         <MatchColumn title="Lower Bracket · раунд 3" matches={bracket.lowerRound3} />
-        <MatchColumn title="Матч за бронзу" matches={[bracket.bronzeFinal]} />
+        <MatchColumn title="Lower Bracket · финал" matches={[bracket.lowerFinal]} />
       </div>
     </section>
   );

--- a/src/features/Cs2Bracket/buildCs2Bracket.js
+++ b/src/features/Cs2Bracket/buildCs2Bracket.js
@@ -14,30 +14,29 @@ const createEmptyMatch = (id, title) => ({
 
 const createBracketSkeleton = () => ({
   upperQuarterfinals: [
-    createEmptyMatch('G1', 'Игра 1'),
-    createEmptyMatch('G2', 'Игра 2'),
-    createEmptyMatch('G3', 'Игра 3'),
-    createEmptyMatch('G4', 'Игра 4'),
+    createEmptyMatch('G1', 'Игра 1 · 17.2'),
+    createEmptyMatch('G2', 'Игра 2 · 17.2'),
+    createEmptyMatch('G3', 'Игра 3 · 17.2'),
+    createEmptyMatch('G4', 'Игра 4 · 17.2'),
   ],
   upperSemifinals: [
-    createEmptyMatch('G5', 'Игра 5'),
-    createEmptyMatch('G6', 'Игра 6'),
+    createEmptyMatch('G5', 'Игра 5 · 21.2'),
+    createEmptyMatch('G6', 'Игра 6 · 21.2'),
   ],
-  upperFinal: createEmptyMatch('G7', 'Игра 7'),
-  grandFinal: createEmptyMatch('GF', 'Гранд-финал'),
+  upperFinal: createEmptyMatch('G7', 'Игра 7 · 25.2'),
+  grandFinal: createEmptyMatch('GF', 'Гранд-финал · 26.2'),
   lowerRound1: [
-    createEmptyMatch('L1', 'Нижняя сетка 1'),
-    createEmptyMatch('L2', 'Нижняя сетка 2'),
+    createEmptyMatch('L1', 'Нижняя сетка 1 · 19.2'),
+    createEmptyMatch('L2', 'Нижняя сетка 2 · 19.2'),
   ],
   lowerRound2: [
-    createEmptyMatch('L3', 'Нижняя сетка 3'),
-    createEmptyMatch('L4', 'Нижняя сетка 4'),
+    createEmptyMatch('L3', 'Нижняя сетка 3 · 24.2'),
+    createEmptyMatch('L4', 'Нижняя сетка 4 · 24.2'),
   ],
   lowerRound3: [
-    createEmptyMatch('L5', 'Нижняя сетка 5'),
-    createEmptyMatch('L6', 'Нижняя сетка 6'),
+    createEmptyMatch('L5', 'Нижняя сетка 5 · 25.2'),
   ],
-  bronzeFinal: createEmptyMatch('BF', 'Матч за бронзу'),
+  lowerFinal: createEmptyMatch('L7', 'Нижняя сетка 7 · 26.2'),
 });
 
 const buildSeedPairs = (teams) => [
@@ -88,7 +87,7 @@ export const buildCs2Bracket = (matchResults) => {
     bottom: pairs[index][1].name,
   }));
 
-  const playoffMatchIds = ['G1', 'G2', 'G3', 'G4', 'G5', 'G6', 'G7', 'L1', 'L2', 'L3', 'L4', 'L5', 'L6', 'BF', 'GF'];
+  const playoffMatchIds = ['G1', 'G2', 'G3', 'G4', 'G5', 'G6', 'G7', 'L1', 'L2', 'L3', 'L4', 'L5', 'L6', 'L7', 'GF'];
   const matchById = {
     G1: bracket.upperQuarterfinals[0],
     G2: bracket.upperQuarterfinals[1],
@@ -102,8 +101,8 @@ export const buildCs2Bracket = (matchResults) => {
     L3: bracket.lowerRound2[0],
     L4: bracket.lowerRound2[1],
     L5: bracket.lowerRound3[0],
-    L6: bracket.lowerRound3[1],
-    BF: bracket.bronzeFinal,
+    L6: bracket.lowerFinal,
+    L7: bracket.lowerFinal,
     GF: bracket.grandFinal,
   };
 
@@ -144,14 +143,11 @@ export const buildCs2Bracket = (matchResults) => {
   bracket.lowerRound3[0].top = bracket.lowerRound3[0].top !== EMPTY_SLOT ? bracket.lowerRound3[0].top : bracket.lowerRound2[0].winner || 'W-L3';
   bracket.lowerRound3[0].bottom = bracket.lowerRound3[0].bottom !== EMPTY_SLOT ? bracket.lowerRound3[0].bottom : bracket.lowerRound2[1].winner || 'W-L4';
 
-  bracket.lowerRound3[1].top = bracket.lowerRound3[1].top !== EMPTY_SLOT ? bracket.lowerRound3[1].top : bracket.lowerRound3[0].winner || 'W-L5';
-  bracket.lowerRound3[1].bottom = bracket.lowerRound3[1].bottom !== EMPTY_SLOT ? bracket.lowerRound3[1].bottom : bracket.upperFinal.loser || 'L7';
-
-  bracket.bronzeFinal.top = bracket.bronzeFinal.top !== EMPTY_SLOT ? bracket.bronzeFinal.top : bracket.lowerRound3[1].winner || 'W-L6';
-  bracket.bronzeFinal.bottom = bracket.bronzeFinal.bottom !== EMPTY_SLOT ? bracket.bronzeFinal.bottom : bracket.upperFinal.loser || 'L7';
+  bracket.lowerFinal.top = bracket.lowerFinal.top !== EMPTY_SLOT ? bracket.lowerFinal.top : bracket.lowerRound3[0].winner || 'W-L5';
+  bracket.lowerFinal.bottom = bracket.lowerFinal.bottom !== EMPTY_SLOT ? bracket.lowerFinal.bottom : bracket.upperFinal.loser || 'L7';
 
   bracket.grandFinal.top = bracket.grandFinal.top !== EMPTY_SLOT ? bracket.grandFinal.top : bracket.upperFinal.winner || 'W7';
-  bracket.grandFinal.bottom = bracket.grandFinal.bottom !== EMPTY_SLOT ? bracket.grandFinal.bottom : bracket.lowerRound3[1].winner || 'W-L6';
+  bracket.grandFinal.bottom = bracket.grandFinal.bottom !== EMPTY_SLOT ? bracket.grandFinal.bottom : bracket.lowerFinal.winner || 'W-L7';
 
   return bracket;
 };

--- a/src/features/Cs2Bracket/buildCs2Bracket.test.js
+++ b/src/features/Cs2Bracket/buildCs2Bracket.test.js
@@ -44,6 +44,10 @@ describe('buildCs2Bracket', () => {
     expect(bracket.upperQuarterfinals[2].bottom).toBe('Team F');
     expect(bracket.upperQuarterfinals[3].top).toBe('Team D');
     expect(bracket.upperQuarterfinals[3].bottom).toBe('Team E');
+    expect(bracket.upperQuarterfinals[0].title).toBe('Игра 1 · 17.2');
+    expect(bracket.lowerRound1[0].title).toBe('Нижняя сетка 1 · 19.2');
+    expect(bracket.lowerFinal.title).toBe('Нижняя сетка 7 · 26.2');
+    expect(bracket.grandFinal.title).toBe('Гранд-финал · 26.2');
   });
 
   it('подтягивает сыгранный матч плей-офф по playoffMatchId', () => {
@@ -96,9 +100,13 @@ describe('buildCs2Bracket', () => {
     expect(bracket.upperQuarterfinals[2].bottom).toBe('Team F');
     expect(bracket.upperQuarterfinals[3].top).toBe('Team D');
     expect(bracket.upperQuarterfinals[3].bottom).toBe('Team E');
+    expect(bracket.upperQuarterfinals[0].title).toBe('Игра 1 · 17.2');
+    expect(bracket.lowerRound1[0].title).toBe('Нижняя сетка 1 · 19.2');
+    expect(bracket.lowerFinal.title).toBe('Нижняя сетка 7 · 26.2');
+    expect(bracket.grandFinal.title).toBe('Гранд-финал · 26.2');
   });
 
-  it('использует победителя нижней сетки в гранд-финале, а не победителя матча за бронзу', () => {
+  it('использует победителя нижней сетки в гранд-финале', () => {
     const resultsWithUpperFinal = {
       rounds: [
         ...baseResults.rounds,
@@ -108,7 +116,6 @@ describe('buildCs2Bracket', () => {
               matches: [
                 createPlayoffMatch('L6', 'Team X', 'Team Y', 2, 1, 'home'),
                 createPlayoffMatch('G7', 'Team A', 'Team B', 2, 0, 'home'),
-                createPlayoffMatch('BF', 'Team Z', 'Team C', 2, 0, 'home'),
               ],
             },
           ],
@@ -120,6 +127,7 @@ describe('buildCs2Bracket', () => {
 
     expect(bracket.grandFinal.top).toBe('Team A');
     expect(bracket.grandFinal.bottom).toBe('Team X');
+    expect(bracket.lowerFinal.title).toBe('Нижняя сетка 7 · 26.2');
   });
 
   it('возвращает пустой каркас, если команд меньше 8', () => {
@@ -127,5 +135,6 @@ describe('buildCs2Bracket', () => {
 
     expect(smallBracket.upperQuarterfinals[0].top).toBe('—');
     expect(smallBracket.grandFinal.bottom).toBe('—');
+    expect(smallBracket.bronzeFinal).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Motivation
- Перенести матч «Финал · 26.2» в отдельный блок справа от «Lower Bracket · раунд 3» и переименовать его в «Нижняя сетка 7 · 26.2» по запросу пользователя.
- Упростить отображение сетки: убрать второй матч в `lowerRound3` и сделать финал нижней сетки отдельным элементом для чистой визуальной структуры.
- Сохранить совместимость с данными плей‑офф, чтобы результат финала нижней сетки подхватывался корректно.

### Description
- Добавлено поле `lowerFinal` в `src/features/Cs2Bracket/buildCs2Bracket.js` и удалён второй слот из `lowerRound3`, с обновлёнными заголовками/датами матчей (`Нижняя сетка 7 · 26.2`).
- Обновлена маппинг‑логика плей‑офф: `playoffMatchId` включает `L6` и `L7`, оба мапятся в `lowerFinal`, и `grandFinal` теперь берёт участника из `lowerFinal`.
- В UI `src/features/Cs2Bracket/Cs2Bracket.jsx` добавлен новый столбец `MatchColumn` с заголовком `Lower Bracket · финал`, расположенный справа от `Lower Bracket · раунд 3`.
- Обновлены unit‑тесты в `src/features/Cs2Bracket/buildCs2Bracket.test.js` для проверки новой структуры и заголовков, а также удалены упоминания `bronzeFinal`.

### Testing
- Запущены unit‑tests через `npm test` (vitest) и все тесты прошли успешно: 27 passed.
- Прогнан линтер через `npm run lint` без ошибок.
- Сборка фронтенда выполнена через `npm run build` успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c5fde33d083278615207ce2fe6e2e)