### PR TITLE
feat(upcoming-matches): сортировка матчей по времени начала

### DIFF
--- a/src/features/UpcomingMatches/UpcomingMatches.jsx
+++ b/src/features/UpcomingMatches/UpcomingMatches.jsx
@@ -4,6 +4,9 @@ import styles from './UpcomingMatches.module.css';
 
 const UpcomingMatches = ({ data }) => {
   const { title, tags, matches, channelPresets } = data;
+  const sortedMatches = [...matches].sort(
+    (leftMatch, rightMatch) => Date.parse(leftMatch.dateTime) - Date.parse(rightMatch.dateTime),
+  );
 
   const resolveChannels = (channelIds) =>
     channelIds
@@ -25,7 +28,7 @@ const UpcomingMatches = ({ data }) => {
         </div>
       </header>
       <ol className={styles.scheduleList}>
-        {matches.map((match) => {
+        {sortedMatches.map((match) => {
           const channels = resolveChannels(match.channelIds);
 
           return (

--- a/src/features/UpcomingMatches/UpcomingMatches.test.jsx
+++ b/src/features/UpcomingMatches/UpcomingMatches.test.jsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+
+import UpcomingMatches from './UpcomingMatches.jsx';
+import config from './config.json';
+
+describe('UpcomingMatches', () => {
+  it('sorts matches by start datetime from earliest to latest', () => {
+    render(<UpcomingMatches data={config} />);
+
+    const list = screen.getByRole('list');
+    const dateTimes = within(list)
+      .getAllByText(/\d{2}:\d{2}/)
+      .map((timeElement) => timeElement.getAttribute('dateTime'));
+
+    expect(dateTimes).toEqual([
+      '2026-02-12T18:00:00+03:00',
+      '2026-02-12T19:00:00+03:00',
+      '2026-02-12T21:00:00+03:00',
+      '2026-02-13T20:00:00+03:00',
+      '2026-02-13T22:00:00+03:00',
+    ]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Обеспечить хронологический порядок матчей в блоке «Расписание ближайших матчей» — от самого раннего старта в четверг до самого позднего старта в пятницу.

### Description
- Добавлена сортировка массива матчей по полю `dateTime` в возрастающем порядке в `src/features/UpcomingMatches/UpcomingMatches.jsx` и заменён рендер на `sortedMatches`; добавлен тест `src/features/UpcomingMatches/UpcomingMatches.test.jsx`, проверяющий ожидаемый порядок `dateTime`.

### Testing
- Запущены автоматические проверки: `npm test` (все тесты прошли), `npm run lint` (без ошибок) и `npm run build` (сборка успешна).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9c20990483279b4dc52d38fab382)