### PR TITLE
feat: CS2 по умолчанию и якорь #counter-strike2

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,7 +46,7 @@ const App = () => {
 
   const [theme, setTheme] = useState(getInitialTheme);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [activeGameDiscipline, setActiveGameDiscipline] = useState('dota2');
+  const [activeGameDiscipline, setActiveGameDiscipline] = useState('cs2');
 
   useEffect(() => {
     const handleResize = () => {
@@ -172,7 +172,7 @@ const App = () => {
             aria-labelledby="tab-cs2"
             hidden={activeGameDiscipline !== 'cs2'}
           >
-            <GameDisciplineSection id="counter-strike-2" title="Counter Strike 2" isExpanded isCollapsible={false}>
+            <GameDisciplineSection id="counter-strike2" title="Counter Strike 2" isExpanded isCollapsible={false}>
               <Cs2TeamShowcase />
               <Cs2LossTables data={cs2LossTablesConfig} matchResults={cs2MatchResultsConfig} />
               <Cs2Bracket matchResults={cs2MatchResultsConfig} />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -7,7 +7,7 @@ const getDisciplineTabList = () => screen.getAllByRole('tablist')
   .find((list) => within(list).queryByRole('tab', { name: 'Dota2' }));
 
 describe('App game discipline switcher', () => {
-  it('renders one section with Dota2 tab active by default', () => {
+  it('renders one section with CS2 tab active by default', () => {
     render(<App />);
 
     expect(screen.getByRole('heading', { name: 'Игровые дисциплины' })).toBeInTheDocument();
@@ -16,11 +16,11 @@ describe('App game discipline switcher', () => {
     const dotaTab = within(tabList).getByRole('tab', { name: 'Dota2' });
     const cs2Tab = within(tabList).getByRole('tab', { name: 'CS2' });
 
-    expect(dotaTab).toHaveAttribute('aria-selected', 'true');
-    expect(cs2Tab).toHaveAttribute('aria-selected', 'false');
+    expect(dotaTab).toHaveAttribute('aria-selected', 'false');
+    expect(cs2Tab).toHaveAttribute('aria-selected', 'true');
 
-    expect(document.getElementById('panel-dota2')).not.toHaveAttribute('hidden');
-    expect(document.getElementById('panel-cs2')).toHaveAttribute('hidden');
+    expect(document.getElementById('panel-dota2')).toHaveAttribute('hidden');
+    expect(document.getElementById('panel-cs2')).not.toHaveAttribute('hidden');
   });
 
   it('switches between Dota2 and CS2 independently', () => {
@@ -46,9 +46,11 @@ describe('App game discipline switcher', () => {
   it('renders roster gallery in both Dota2 and CS2 sections', () => {
     render(<App />);
 
+    const tabList = getDisciplineTabList();
+    fireEvent.click(within(tabList).getByRole('tab', { name: 'Dota2' }));
+
     expect(within(document.getElementById('panel-dota2')).getAllByRole('heading', { name: 'Галерея ростеров' })).toHaveLength(1);
 
-    const tabList = getDisciplineTabList();
     fireEvent.click(within(tabList).getByRole('tab', { name: 'CS2' }));
 
     expect(within(document.getElementById('panel-cs2')).getAllByRole('heading', { name: 'Галерея ростеров' })).toHaveLength(1);


### PR DESCRIPTION
### Motivation
- Сделать CS2 видимым по умолчанию в блоке «Игровые дисциплины» и обеспечить работу якоря `#counter-strike2` для прямого перехода к секции.

### Description
- Изменён начальный стейт переключателя: `activeGameDiscipline` теперь инициализируется как `cs2` в `src/App.jsx`.
- Обновлён `id` CS2-секции с `counter-strike-2` на `counter-strike2` в `src/App.jsx` для поддержки якоря `#counter-strike2`.
- Скорректированы тесты в `src/App.test.jsx` под новое поведение по умолчанию (ожидания `aria-selected` и видимости панелей).

### Testing
- Выполнены команды `npm run lint`, `npm run test` и `npm run build`, все проверки прошли успешно (`vitest`: 27 тестов, 27 passed).
- Локально проверено поведение UI и якоря через dev-сервер и снят скриншот состояния с CS2 открытым по умолчанию.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d9cbf75788327a17ad4b03af0b64a)