### PR TITLE
feat(cs2): добавить раунд «Плей-офф · Верхняя сетка 1/4»

### DIFF
--- a/src/features/MatchResults/cs2-config.json
+++ b/src/features/MatchResults/cs2-config.json
@@ -665,6 +665,110 @@
           ]
         }
       ]
+    },
+    {
+      "id": "cs2-round-playoff-upper-qf",
+      "title": "Плей-офф · Верхняя сетка 1/4",
+      "subtitle": "Upper Bracket · 1/4",
+      "defaultExpanded": true,
+      "weeks": [
+        {
+          "id": "cs2-week-playoff-upper-qf",
+          "title": "Upper Bracket · 1/4 · 17.2",
+          "matches": [
+            {
+              "id": "2026-02-17-upper-qf-g1-ligachad-slabeyshie",
+              "playoffMatchId": "G1",
+              "dateLabel": "17.2",
+              "dateTime": "2026-02-17",
+              "stage": "Игра 1",
+              "teams": {
+                "home": "LigaChad",
+                "away": "Slabeyshie"
+              },
+              "score": {
+                "home": 1,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 16,
+                    "away": 14
+                  }
+                }
+              ],
+              "bestOf": 1,
+              "status": "finished",
+              "statusLabel": "1–0 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-17-upper-qf-g1-ligachad-slabeyshie",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-02-17-upper-qf-g2-resistance-cipher",
+              "playoffMatchId": "G2",
+              "dateLabel": "17.2",
+              "dateTime": "2026-02-17",
+              "stage": "Игра 2",
+              "teams": {
+                "home": "Resistance",
+                "away": "CipHer"
+              },
+              "score": {
+                "home": 1,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 13,
+                    "away": 11
+                  }
+                }
+              ],
+              "bestOf": 1,
+              "status": "finished",
+              "statusLabel": "1–0 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-17-upper-qf-g2-resistance-cipher",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-02-17-upper-qf-g3-vpopengagen-wolves-kit",
+              "playoffMatchId": "G3",
+              "dateLabel": "17.2",
+              "dateTime": "2026-02-17",
+              "stage": "Игра 3",
+              "teams": {
+                "home": "Vpopengagen wolves",
+                "away": "КИТ, Кипар и татары"
+              },
+              "score": {
+                "home": 1,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 13,
+                    "away": 3
+                  }
+                }
+              ],
+              "bestOf": 1,
+              "status": "finished",
+              "statusLabel": "1–0 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-17-upper-qf-g3-vpopengagen-wolves-kit",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Показать отдельный раунд плей‑офф (Upper Bracket 1/4) в блоке результатов с датой `17.2` без времени и возможностью подтянуть результаты в сетку по `playoffMatchId`.
- Оставить четвёртую игру пустой/ожидаемой для последующего заполнения без влияния на таблицу квалификации.

### Description
- Добавлен новый раунд в `src/features/MatchResults/cs2-config.json` с `id: cs2-round-playoff-upper-qf` и недетализированной датой `17.2` в `dateLabel`/`dateTime` для всех матчей раунда.
- Добавлены 3 завершённых матча с `playoffMatchId` `G1`–`G3` и указанными счётами/картами для автоматической синхронизации с сеткой; четвёртая игра не добавлена как завершённая (остается scheduled/ожидается).
- Изменение касается только данных конфигурации матчей; существующая логика, которая исключает матчи с `playoffMatchId` из таблицы квалификации, не менялась.

### Testing
- Запущены проверки: `npm run lint`, `npm run test`, `npm run build`, `npm run lint:assets` и все они успешно завершились. 
- Юнит‑тесты (Vitest) — пройдены: все тесты в проекте успешны. 
- Билд (Vite) — успешная сборка продакшн‑бандла.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ca722af483278c46bc583384094d)