### PR TITLE
feat(cs2): добавить результаты 1/4 нижней сетки

### DIFF
--- a/src/features/MatchResults/cs2-config.json
+++ b/src/features/MatchResults/cs2-config.json
@@ -799,6 +799,101 @@
           ]
         }
       ]
+    },
+    {
+      "id": "cs2-round-playoff-lower-qf",
+      "title": "Плей-офф · Нижняя сетка 1/4",
+      "subtitle": "Lower Bracket · 1/4",
+      "defaultExpanded": true,
+      "weeks": [
+        {
+          "id": "cs2-week-playoff-lower-qf",
+          "title": "Lower Bracket · 1/4 · 18.2",
+          "matches": [
+            {
+              "id": "2026-02-18-lower-qf-l1-cipher-slabeyshie",
+              "playoffMatchId": "L1",
+              "dateLabel": "18.2",
+              "dateTime": "2026-02-18",
+              "stage": "Игра 1",
+              "teams": {
+                "home": "CipHer",
+                "away": "Slabeyshie"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 4,
+                    "away": 13
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 6,
+                    "away": 13
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-18-lower-qf-l1-cipher-slabeyshie",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-02-18-lower-qf-l2-saint-worms-kit",
+              "playoffMatchId": "L2",
+              "dateLabel": "18.2",
+              "dateTime": "2026-02-18",
+              "stage": "Игра 2",
+              "teams": {
+                "home": "Saint Worms",
+                "away": "КИТ, Кипар и татары"
+              },
+              "score": {
+                "home": 2,
+                "away": 1
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 13,
+                    "away": 3
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 9,
+                    "away": 13
+                  }
+                },
+                {
+                  "id": "game-3",
+                  "score": {
+                    "home": 13,
+                    "away": 10
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–1 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-18-lower-qf-l2-saint-worms-kit",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Зафиксировать завершённые матчи нижней сетки (1/4) CS2 в конфиге, чтобы они отображались в результатах и корректно подхватывались в турнирной логике.

### Description
- Добавлен раунд `cs2-round-playoff-lower-qf` в `src/features/MatchResults/cs2-config.json` с заголовком «Плей-офф · Нижняя сетка 1/4». 
- Добавлены два завершённых матча: `L1` — `CipHer` vs `Slabeyshie` (0:2, карты 4:13, 6:13) и `L2` — `Saint Worms` vs `КИТ, Кипар и татары` (2:1, карты 13:3, 9:13, 13:10). 
- Изменения затрагивают только JSON-конфигурацию матчей, без правок бизнес-логики, API или публичных контрактов.

### Testing
- Запущено `npm run lint` — успешно. 
- Запущено `npm run test` — все тесты прошли (28 passed). 
- Запущено `npm run build` — сборка прошла успешно. 
- Запущено `npm run lint:assets` — успешно. 
- `npm run typecheck` — скрипт отсутствует в `package.json` (ошибка конфигурации, не применимо к изменению).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997727659548327ae04eafa63f88d2e)