### PR TITLE
feat(cs2): обновить результаты полуфиналов верхней сетки

### DIFF
--- a/src/features/MatchResults/cs2-config.json
+++ b/src/features/MatchResults/cs2-config.json
@@ -894,6 +894,101 @@
           ]
         }
       ]
+    },
+    {
+      "id": "cs2-round-playoff-upper-sf",
+      "title": "Плей-офф · Верхняя сетка 1/2",
+      "subtitle": "Upper Bracket · 1/2",
+      "defaultExpanded": true,
+      "weeks": [
+        {
+          "id": "cs2-week-playoff-upper-sf",
+          "title": "Upper Bracket · 1/2 · 21.2",
+          "matches": [
+            {
+              "id": "2026-02-21-upper-sf-g5-ligachad-resistance",
+              "playoffMatchId": "G5",
+              "dateLabel": "21.2",
+              "dateTime": "2026-02-21",
+              "stage": "Игра 5",
+              "teams": {
+                "home": "LigaChad",
+                "away": "Resistance"
+              },
+              "score": {
+                "home": 1,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 7,
+                    "away": 13
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 13,
+                    "away": 7
+                  }
+                },
+                {
+                  "id": "game-3",
+                  "score": {
+                    "home": 14,
+                    "away": 16
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "1–2 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-21-upper-sf-g5-ligachad-resistance",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-02-21-upper-sf-g6-vpopengagen-wolves-fist-beer",
+              "playoffMatchId": "G6",
+              "dateLabel": "21.2",
+              "dateTime": "2026-02-21",
+              "stage": "Игра 6",
+              "teams": {
+                "home": "Vpopengagen wolves",
+                "away": "FIST&BEER"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 13,
+                    "away": 9
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 13,
+                    "away": 4
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-21-upper-sf-g6-vpopengagen-wolves-fist-beer",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Обновить турнирную сетку CS2 в интерфейсе после завершения полуфиналов верхней сетки.
- Обеспечить автоматическое подхватывание результатов компонентом сборки сетки через конфиг матчей.

### Description
- Добавлен раунд `Плей-офф · Верхняя сетка 1/2` в `src/features/MatchResults/cs2-config.json` с матчами `playoffMatchId: G5` и `G6`.
- В каждой записи указаны команды, итоговые счёты, подробные `maps`, `bestOf`, `status`, `statusLabel` и `winner` для корректного отображения в сетке.
- Изменения содержат только контентные данные (JSON) и не затрагивают логику, API или зависимости, поэтому совместимы с текущим `buildCs2Bracket`.

### Testing
- `npm run lint` — успешно.
- `npm run test` — успешно, все тесты прошли (`28 passed`).
- `npm run build` — успешно.
- `npm run typecheck` — скрипт отсутствует в `package.json` (типизация не проверялась автоматическим скриптом).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b56ce0b98832786446d69d1e3cb6a)