### PR TITLE
feat(cs2): добавить результаты матчей 2-го раунда нижней сетки

### DIFF
--- a/src/features/MatchResults/cs2-config.json
+++ b/src/features/MatchResults/cs2-config.json
@@ -989,6 +989,94 @@
           ]
         }
       ]
+    },
+    {
+      "id": "cs2-round-playoff-lower-r2",
+      "title": "Плей-офф · Нижняя сетка 2 раунд",
+      "subtitle": "Lower Bracket · Round 2",
+      "defaultExpanded": true,
+      "weeks": [
+        {
+          "id": "cs2-week-playoff-lower-r2",
+          "title": "Lower Bracket · Round 2 · 24.2",
+          "matches": [
+            {
+              "id": "2026-02-24-lower-r2-l3-slabeyshie-ligachad",
+              "playoffMatchId": "L3",
+              "dateLabel": "24.2",
+              "dateTime": "2026-02-24",
+              "stage": "Игра 3",
+              "teams": {
+                "home": "Slabeyshie",
+                "away": "LigaChad"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 8,
+                    "away": 13
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 2,
+                    "away": 13
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-24-lower-r2-l3-slabeyshie-ligachad",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-02-24-lower-r2-l4-saint-worms-fist-beer",
+              "playoffMatchId": "L4",
+              "dateLabel": "24.2",
+              "dateTime": "2026-02-24",
+              "stage": "Игра 4",
+              "teams": {
+                "home": "Saint Worms",
+                "away": "FIST&BEER"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 13,
+                    "away": 9
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 13,
+                    "away": 4
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-24-lower-r2-l4-saint-worms-fist-beer",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Отобразить сыгранные матчи 2-го раунда нижней сетки CS2 в списке матчей и брекете, чтобы результаты появились на сайте.

### Description
- Добавлен раздел `cs2-round-playoff-lower-r2` в файл `src/features/MatchResults/cs2-config.json` с двумя матчами и датой `24.2`.
- Добавлены результаты: `Slabeyshie vs LigaChad 0:2` (карты `8:13`, `2:13`, `playoffMatchId: L3`) и `Saint Worms vs FIST&BEER 2:0` (карты `13:9`, `13:4`, `playoffMatchId: L4`).
- Логика сборки брекета не менялась, существующий `buildCs2Bracket` автоматически подхватит эти матчи по `playoffMatchId`, риск изменений — низкий.

### Testing
- `npm run lint` — успешно.
- `npm run test` (Vitest) — все тесты пройдены (`28 passed`).
- `npm run build` — сборка прошла успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dfc2581608327976160d490863f25)