### PR TITLE
feat(match-results): добавить результаты финала верхней и 3-го раунда нижней сетки CS2

### DIFF
--- a/src/features/MatchResults/cs2-config.json
+++ b/src/features/MatchResults/cs2-config.json
@@ -1077,6 +1077,108 @@
           ]
         }
       ]
+    },
+    {
+      "id": "cs2-round-playoff-upper-final",
+      "title": "Плей-офф · Финал верхней сетки",
+      "subtitle": "Upper Bracket · Final",
+      "defaultExpanded": true,
+      "weeks": [
+        {
+          "id": "cs2-week-playoff-upper-final",
+          "title": "Upper Bracket · Final · 25.2",
+          "matches": [
+            {
+              "id": "2026-02-25-upper-final-g7-resistance-vpopengagen-wolves",
+              "playoffMatchId": "G7",
+              "dateLabel": "25.2",
+              "dateTime": "2026-02-25",
+              "stage": "Игра 7",
+              "teams": {
+                "home": "Resistance",
+                "away": "Vpopengagen wolves"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 13,
+                    "away": 10
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 13,
+                    "away": 8
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-25-upper-final-g7-resistance-vpopengagen-wolves",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "cs2-round-playoff-lower-r3",
+      "title": "Плей-офф · Нижняя сетка 3 раунд",
+      "subtitle": "Lower Bracket · Round 3",
+      "defaultExpanded": true,
+      "weeks": [
+        {
+          "id": "cs2-week-playoff-lower-r3",
+          "title": "Lower Bracket · Round 3 · 25.2",
+          "matches": [
+            {
+              "id": "2026-02-25-lower-r3-l5-ligachad-saint-worms",
+              "playoffMatchId": "L5",
+              "dateLabel": "25.2",
+              "dateTime": "2026-02-25",
+              "stage": "Игра 5",
+              "teams": {
+                "home": "LigaChad",
+                "away": "Saint Worms"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "maps": [
+                {
+                  "id": "game-1",
+                  "score": {
+                    "home": 13,
+                    "away": 11
+                  }
+                },
+                {
+                  "id": "game-2",
+                  "score": {
+                    "home": 13,
+                    "away": 7
+                  }
+                }
+              ],
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/cs2-2026-02-25-lower-r3-l5-ligachad-saint-worms",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Внести актуальные результаты плей-офф CS2 в конфигурационный файл матчей для корректного отображения на сайте.
- Навык: не использовался — изменение внесено напрямую в JSON-конфиг (`src/features/MatchResults/cs2-config.json`).
- Риск низкий: затронут только контентный JSON без изменений бизнес-логики или публичных API.

### Description
- Добавлен раунд `Плей-офф · Финал верхней сетки` с матчем `Resistance — Vpopengagen wolves` (playoffMatchId: `G7`) и результатом `2:0`, заполнены карты, статус и победитель.
- Добавлен раунд `Плей-офф · Нижняя сетка 3 раунд` с матчем `LigaChad — Saint Worms` (playoffMatchId: `L5`) и результатом `2:0`, заполнены карты, статус и победитель.
- Изменён файл `src/features/MatchResults/cs2-config.json` (добавлено 102 строки данных) и выполнён коммит с сообщением `feat(match-results): add CS2 upper/lower playoff results`.
- Не вносились изменения в код, API, схемы данных или зависимости.

### Testing
- Запущен линтер `npm run lint` и завершился успешно.
- Прогон тестов `npm run test` (Vitest) — все тесты успешны: 28 passed (0 failed).
- Сборка `npm run build` выполнена успешно (Vite успешно собрал продакшн-бандлы).
- Валидация JSON `node -e "JSON.parse(...)"` прошла успешно (файл корректный).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f41caec2c8327b6d17c53ca68b17f)