### PR TITLE
fix(hero): обновить даты Dota 2 и активировать кнопку регламента

### DIFF
--- a/src/features/Hero/Hero.jsx
+++ b/src/features/Hero/Hero.jsx
@@ -90,7 +90,7 @@ const Hero = ({ data }) => {
   const shouldRenderVideo = videoSources.length > 0;
   const fallbackImage = media?.fallbackImage || defaultFallbackImage;
   const posterImage = media?.poster || defaultFallbackImage;
-  const disabledCtaLabels = new Set(['Регламент Dota 2', 'Регламент CS2', 'Регламент LAN']);
+  const disabledCtaLabels = new Set(['Регламент CS2', 'Регламент LAN']);
 
   return (
     <div className="hero hero--versus">
@@ -204,6 +204,8 @@ const Hero = ({ data }) => {
                         }`}
                         href={fact.cta.href}
                         aria-label={fact.cta.ariaLabel || fact.cta.label}
+                        target={fact.cta.newTab ? '_blank' : undefined}
+                        rel={fact.cta.newTab ? 'noopener noreferrer' : undefined}
                       >
                         {fact.cta.label}
                       </a>
@@ -318,6 +320,7 @@ Hero.propTypes = {
           label: PropTypes.string.isRequired,
           href: PropTypes.string.isRequired,
           ariaLabel: PropTypes.string,
+          newTab: PropTypes.bool,
         }),
       })
     ),

--- a/src/features/Hero/config.json
+++ b/src/features/Hero/config.json
@@ -19,11 +19,12 @@
     {
       "tag": "DOTA 2",
       "title": "Основной этап Dota 2",
-      "value": "10 марта - 30 апреля'26",
+      "value": "25 марта 2026 - 26 апреля 2026 года",
       "description": "включен в ЕКП",
       "cta": {
         "label": "Регламент Dota 2",
-        "href": "/docs/ycs-dota2-mainstage.pdf",
+        "href": "/docs/reglament-dota2-ver1.pdf",
+        "newTab": true,
         "ariaLabel": "Открыть регламент основного этапа Dota 2"
       }
     },


### PR DESCRIPTION
### Motivation
- Обновить отображаемые даты этапа Dota 2 и сделать кнопку «Регламент Dota 2» кликабельной для открытия актуального PDF в новой вкладке. 
- Изменения локальны для hero-конфига и рендера CTA, риск низкий (без изменения API/контрактов).

### Description
- В `src/features/Hero/config.json` заменён `value` для DOTA 2 на `25 марта 2026 - 26 апреля 2026 года` и обновлён `cta.href` на `/docs/reglament-dota2-ver1.pdf` с добавлением `newTab: true`.
- В `src/features/Hero/Hero.jsx` удалено принудительное отключение CTA «Регламент Dota 2» из списка запрещённых меток, оставив только CS2 и LAN.
- В `Hero.jsx` добавлена поддержка открытия CTA в новой вкладке через `target={...}` и безопасный `rel="noopener noreferrer"` при `cta.newTab`.
- Обновлены `PropTypes` для нового поля `cta.newTab`.

### Testing
- Запущен линтер: `npm run lint` — успешно.
- Запущены юнит/интеграционные тесты: `npm run test` — все тесты прошли успешно.
- Собрана прод-версиия: `npm run build` — сборка прошла успешно.
- Проверка имён ассетов: `npm run lint:assets` — успешно.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b15120c694832782933ee3f1b12b76)