### PR TITLE
Split Dota tabs, add Dota 2 Main groups panel and update tests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import Cs2LossTables from './features/QualificationsTable/Cs2LossTables.jsx';
 import Cs2Bracket from './features/Cs2Bracket/Cs2Bracket.jsx';
 import cs2LossTablesConfig from './features/QualificationsTable/cs2-loss-config.json';
 import GameDisciplineSection from './components/GameDisciplineSection.jsx';
+import DotaMainGroups from './features/DotaMainGroups/DotaMainGroups.jsx';
 import logoImage from './brand-logo.png';
 import './App.css';
 
@@ -46,7 +47,7 @@ const App = () => {
 
   const [theme, setTheme] = useState(getInitialTheme);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [activeGameDiscipline, setActiveGameDiscipline] = useState('cs2');
+  const [activeGameDiscipline, setActiveGameDiscipline] = useState('dota2-main');
 
   useEffect(() => {
     const handleResize = () => {
@@ -131,13 +132,24 @@ const App = () => {
               <button
                 type="button"
                 role="tab"
-                id="tab-dota2"
-                aria-selected={activeGameDiscipline === 'dota2'}
-                aria-controls="panel-dota2"
-                className={`game-disciplines-switcher__tab${activeGameDiscipline === 'dota2' ? ' game-disciplines-switcher__tab--active' : ''}`}
-                onClick={() => setActiveGameDiscipline('dota2')}
+                id="tab-dota2-main"
+                aria-selected={activeGameDiscipline === 'dota2-main'}
+                aria-controls="panel-dota2-main"
+                className={`game-disciplines-switcher__tab${activeGameDiscipline === 'dota2-main' ? ' game-disciplines-switcher__tab--active' : ''}`}
+                onClick={() => setActiveGameDiscipline('dota2-main')}
               >
-                Dota2
+                Dota 2.Main
+              </button>
+              <button
+                type="button"
+                role="tab"
+                id="tab-dota2-qual"
+                aria-selected={activeGameDiscipline === 'dota2-qual'}
+                aria-controls="panel-dota2-qual"
+                className={`game-disciplines-switcher__tab${activeGameDiscipline === 'dota2-qual' ? ' game-disciplines-switcher__tab--active' : ''}`}
+                onClick={() => setActiveGameDiscipline('dota2-qual')}
+              >
+                DotA 2.Qual
               </button>
               <button
                 type="button"
@@ -155,11 +167,22 @@ const App = () => {
 
           <div
             role="tabpanel"
-            id="panel-dota2"
-            aria-labelledby="tab-dota2"
-            hidden={activeGameDiscipline !== 'dota2'}
+            id="panel-dota2-main"
+            aria-labelledby="tab-dota2-main"
+            hidden={activeGameDiscipline !== 'dota2-main'}
           >
-            <GameDisciplineSection id="dota-2" title="Dota 2" isExpanded isCollapsible={false}>
+            <GameDisciplineSection id="dota-2-main" title="Dota 2.Main" isExpanded isCollapsible={false}>
+              <DotaMainGroups />
+            </GameDisciplineSection>
+          </div>
+
+          <div
+            role="tabpanel"
+            id="panel-dota2-qual"
+            aria-labelledby="tab-dota2-qual"
+            hidden={activeGameDiscipline !== 'dota2-qual'}
+          >
+            <GameDisciplineSection id="dota-2-qual" title="DotA 2.Qual" isExpanded isCollapsible={false}>
               <TeamShowcase />
               <QualificationsTable data={qualificationsConfig} matchResults={matchResultsConfig} />
               <MatchResults data={matchResultsConfig} />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -4,52 +4,68 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import App from './App.jsx';
 
 const getDisciplineTabList = () => screen.getAllByRole('tablist')
-  .find((list) => within(list).queryByRole('tab', { name: 'Dota2' }));
+  .find((list) => within(list).queryByRole('tab', { name: 'Dota 2.Main' }));
 
 describe('App game discipline switcher', () => {
-  it('renders one section with CS2 tab active by default', () => {
+  it('renders one section with Dota 2.Main tab active by default', () => {
     render(<App />);
 
     expect(screen.getByRole('heading', { name: 'Игровые дисциплины' })).toBeInTheDocument();
 
     const tabList = getDisciplineTabList();
-    const dotaTab = within(tabList).getByRole('tab', { name: 'Dota2' });
+    const dotaMainTab = within(tabList).getByRole('tab', { name: 'Dota 2.Main' });
+    const dotaQualTab = within(tabList).getByRole('tab', { name: 'DotA 2.Qual' });
     const cs2Tab = within(tabList).getByRole('tab', { name: 'CS2' });
 
-    expect(dotaTab).toHaveAttribute('aria-selected', 'false');
-    expect(cs2Tab).toHaveAttribute('aria-selected', 'true');
+    expect(dotaMainTab).toHaveAttribute('aria-selected', 'true');
+    expect(dotaQualTab).toHaveAttribute('aria-selected', 'false');
+    expect(cs2Tab).toHaveAttribute('aria-selected', 'false');
 
-    expect(document.getElementById('panel-dota2')).toHaveAttribute('hidden');
-    expect(document.getElementById('panel-cs2')).not.toHaveAttribute('hidden');
+    expect(document.getElementById('panel-dota2-main')).not.toHaveAttribute('hidden');
+    expect(document.getElementById('panel-dota2-qual')).toHaveAttribute('hidden');
+    expect(document.getElementById('panel-cs2')).toHaveAttribute('hidden');
   });
 
-  it('switches between Dota2 and CS2 independently', () => {
+  it('switches between Dota 2.Main, DotA 2.Qual and CS2 independently', () => {
     render(<App />);
 
     const tabList = getDisciplineTabList();
+    const dotaMainTab = within(tabList).getByRole('tab', { name: 'Dota 2.Main' });
+    const dotaQualTab = within(tabList).getByRole('tab', { name: 'DotA 2.Qual' });
     const cs2Tab = within(tabList).getByRole('tab', { name: 'CS2' });
+
+    fireEvent.click(dotaQualTab);
+
+    expect(document.getElementById('panel-dota2-qual')).not.toHaveAttribute('hidden');
+    expect(document.getElementById('panel-dota2-main')).toHaveAttribute('hidden');
+    expect(document.getElementById('panel-cs2')).toHaveAttribute('hidden');
+    expect(within(document.getElementById('panel-dota2-qual')).getByRole('heading', { name: 'DotA 2.Qual' })).toBeInTheDocument();
+
     fireEvent.click(cs2Tab);
 
     expect(document.getElementById('panel-cs2')).not.toHaveAttribute('hidden');
-    expect(document.getElementById('panel-dota2')).toHaveAttribute('hidden');
+    expect(document.getElementById('panel-dota2-main')).toHaveAttribute('hidden');
+    expect(document.getElementById('panel-dota2-qual')).toHaveAttribute('hidden');
 
     expect(within(document.getElementById('panel-cs2')).getByRole('heading', { name: 'Counter Strike 2' })).toBeInTheDocument();
 
-    const dotaTab = within(tabList).getByRole('tab', { name: 'Dota2' });
-    fireEvent.click(dotaTab);
+    fireEvent.click(dotaMainTab);
 
-    expect(document.getElementById('panel-dota2')).not.toHaveAttribute('hidden');
+    expect(document.getElementById('panel-dota2-main')).not.toHaveAttribute('hidden');
+    expect(document.getElementById('panel-dota2-qual')).toHaveAttribute('hidden');
     expect(document.getElementById('panel-cs2')).toHaveAttribute('hidden');
-    expect(within(document.getElementById('panel-dota2')).getByRole('heading', { name: 'Dota 2' })).toBeInTheDocument();
+    expect(within(document.getElementById('panel-dota2-main')).getByRole('heading', { name: 'Dota 2.Main' })).toBeInTheDocument();
   });
 
-  it('renders roster gallery in both Dota2 and CS2 sections', () => {
+  it('renders group stage in Dota 2.Main and roster gallery in DotA 2.Qual and CS2 sections', () => {
     render(<App />);
 
     const tabList = getDisciplineTabList();
-    fireEvent.click(within(tabList).getByRole('tab', { name: 'Dota2' }));
+    fireEvent.click(within(tabList).getByRole('tab', { name: 'Dota 2.Main' }));
+    expect(within(document.getElementById('panel-dota2-main')).getByRole('heading', { name: 'Групповой этап' })).toBeInTheDocument();
 
-    expect(within(document.getElementById('panel-dota2')).getAllByRole('heading', { name: 'Галерея ростеров' })).toHaveLength(1);
+    fireEvent.click(within(tabList).getByRole('tab', { name: 'DotA 2.Qual' }));
+    expect(within(document.getElementById('panel-dota2-qual')).getAllByRole('heading', { name: 'Галерея ростеров' })).toHaveLength(1);
 
     fireEvent.click(within(tabList).getByRole('tab', { name: 'CS2' }));
 

--- a/src/features/DotaMainGroups/DotaMainGroups.css
+++ b/src/features/DotaMainGroups/DotaMainGroups.css
@@ -1,0 +1,49 @@
+.dota-main-groups {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  background: rgba(10, 14, 29, 0.55);
+}
+
+.dota-main-groups__title {
+  margin: 0 0 var(--space-3);
+  color: var(--color-text-primary);
+  font-size: clamp(1.05rem, 0.95rem + 0.55vw, 1.3rem);
+}
+
+.dota-main-groups__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+
+.dota-main-groups__card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  background: rgba(18, 24, 46, 0.75);
+}
+
+.dota-main-groups__group-title {
+  margin: 0 0 var(--space-2);
+  color: var(--color-text-primary);
+  font-size: 1rem;
+}
+
+.dota-main-groups__team-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+  color: var(--color-text-secondary);
+}
+
+.dota-main-groups__team-item {
+  line-height: 1.35;
+}
+
+@media (max-width: 768px) {
+  .dota-main-groups__grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/features/DotaMainGroups/DotaMainGroups.jsx
+++ b/src/features/DotaMainGroups/DotaMainGroups.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+
+import './DotaMainGroups.css';
+import groupsConfig from './config.json';
+
+const DotaMainGroups = ({ data = groupsConfig }) => (
+  <section className="dota-main-groups" aria-labelledby="dota-main-groups-title">
+    <h4 id="dota-main-groups-title" className="dota-main-groups__title">{data.title}</h4>
+    <div className="dota-main-groups__grid">
+      {(data.groups ?? []).map((group) => (
+        <article key={group.name} className="dota-main-groups__card" aria-label={group.name}>
+          <h5 className="dota-main-groups__group-title">{group.name}</h5>
+          <ul className="dota-main-groups__team-list">
+            {(group.teams ?? []).map((team) => (
+              <li key={`${group.name}-${team}`} className="dota-main-groups__team-item">{team}</li>
+            ))}
+          </ul>
+        </article>
+      ))}
+    </div>
+  </section>
+);
+
+DotaMainGroups.propTypes = {
+  data: PropTypes.shape({
+    title: PropTypes.string,
+    groups: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        teams: PropTypes.arrayOf(PropTypes.string).isRequired,
+      }),
+    ),
+  }),
+};
+
+export default DotaMainGroups;

--- a/src/features/DotaMainGroups/config.json
+++ b/src/features/DotaMainGroups/config.json
@@ -1,0 +1,21 @@
+{
+  "title": "Групповой этап",
+  "groups": [
+    {
+      "name": "A группа",
+      "teams": ["Самозванцы", "Japan", "Колбасный Цэх", "Yellow Submarine"]
+    },
+    {
+      "name": "B группа",
+      "teams": ["Podpivas Team", "Mi Ne Pushim", "Buyback Academy", "afk30"]
+    },
+    {
+      "name": "C группа",
+      "teams": ["Tech Titans", "Ягк", "Синергия", "Вифк"]
+    },
+    {
+      "name": "D группа",
+      "teams": ["Way Prod.", "Гики", "Steel Titans", "Team Borisogleb"]
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Introduce a dedicated "Dota 2.Main" view to show the group-stage lineup separately from the qualifiers view.
- Update the game-discipline switcher to support two Dota-related tabs and ensure correct accessibility attributes and panel IDs.
- Provide a reusable component to render the group-stage data driven by a JSON config.

### Description
- Added `DotaMainGroups` component (`src/features/DotaMainGroups/DotaMainGroups.jsx`) with its stylesheet (`.css`) and data (`config.json`) to render group-stage cards and team lists.
- Wired the new component into the app by importing `DotaMainGroups` in `src/App.jsx` and adding a new `Dota 2.Main` tab and a separate `DotA 2.Qual` tab, updating tab IDs, panel IDs, aria attributes, and the default `activeGameDiscipline` to `dota2-main`.
- Updated the Dota qualification panel ID/title to `dota-2-qual` / `DotA 2.Qual`, and adjusted class names and `GameDisciplineSection` usage accordingly.
- Updated unit tests in `src/App.test.jsx` to reflect the new tab labels, panel IDs, and expected behaviors for `Dota 2.Main`, `DotA 2.Qual`, and `CS2`.

### Testing
- Ran unit tests with `vitest` and the updated `@testing-library/react` assertions in `src/App.test.jsx`. All tests passed.
- Verified accessibility roles and panel visibility assertions in tests for tab switching scenarios, which succeeded under the test suite.
- No runtime or integration tests were modified beyond the updated unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4e01c8d848327a88cd5a8934f36fe)