### PR TITLE
Выровнять структуру Dota2.Main под Dota2.Qual

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,7 +25,6 @@ import Cs2LossTables from './features/QualificationsTable/Cs2LossTables.jsx';
 import Cs2Bracket from './features/Cs2Bracket/Cs2Bracket.jsx';
 import cs2LossTablesConfig from './features/QualificationsTable/cs2-loss-config.json';
 import GameDisciplineSection from './components/GameDisciplineSection.jsx';
-import DotaMainGroups from './features/DotaMainGroups/DotaMainGroups.jsx';
 import logoImage from './brand-logo.png';
 import './App.css';
 
@@ -172,7 +171,9 @@ const App = () => {
             hidden={activeGameDiscipline !== 'dota2-main'}
           >
             <GameDisciplineSection id="dota-2-main" title="Dota 2.Main" isExpanded isCollapsible={false}>
-              <DotaMainGroups />
+              <TeamShowcase />
+              <QualificationsTable data={qualificationsConfig} matchResults={matchResultsConfig} />
+              <MatchResults data={matchResultsConfig} />
             </GameDisciplineSection>
           </div>
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -57,12 +57,13 @@ describe('App game discipline switcher', () => {
     expect(within(document.getElementById('panel-dota2-main')).getByRole('heading', { name: 'Dota 2.Main' })).toBeInTheDocument();
   });
 
-  it('renders group stage in Dota 2.Main and roster gallery in DotA 2.Qual and CS2 sections', () => {
+  it('renders roster galleries and match blocks in Dota 2.Main, DotA 2.Qual and CS2 sections', () => {
     render(<App />);
 
     const tabList = getDisciplineTabList();
     fireEvent.click(within(tabList).getByRole('tab', { name: 'Dota 2.Main' }));
-    expect(within(document.getElementById('panel-dota2-main')).getByRole('heading', { name: 'Групповой этап' })).toBeInTheDocument();
+    expect(within(document.getElementById('panel-dota2-main')).getAllByRole('heading', { name: 'Галерея ростеров' })).toHaveLength(1);
+    expect(within(document.getElementById('panel-dota2-main')).getByRole('heading', { name: 'Результаты последних матчей' })).toBeInTheDocument();
 
     fireEvent.click(within(tabList).getByRole('tab', { name: 'DotA 2.Qual' }));
     expect(within(document.getElementById('panel-dota2-qual')).getAllByRole('heading', { name: 'Галерея ростеров' })).toHaveLength(1);


### PR DESCRIPTION
### Motivation
- Команды из квалификации играют в main, поэтому нужно переиспользовать ростеры и избежать дублирования в UI.

### Description
- В `Dota 2.Main` заменён блок групп на ту же композицию, что в `DotA 2.Qual`: `TeamShowcase`, `QualificationsTable`, `MatchResults`; удалён `DotaMainGroups` (изменены `src/App.jsx` и `src/App.test.jsx`).

### Testing
- Запущены проверки `npm run lint`, `npm run test`, `npm run build` и `npm run lint:assets`, все успешно прошли.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4f63b67ec8327b8473ac439314814)