### PR TITLE
feat(dota-main): обновить состав групп и добавить колонки таблиц

### DIFF
--- a/src/features/DotaMainGroups/DotaMainGroups.css
+++ b/src/features/DotaMainGroups/DotaMainGroups.css
@@ -30,16 +30,37 @@
   font-size: 1rem;
 }
 
-.dota-main-groups__team-list {
-  margin: 0;
-  padding-left: 1.2rem;
-  display: grid;
-  gap: 0.35rem;
-  color: var(--color-text-secondary);
+.dota-main-groups__table-wrapper {
+  overflow-x: auto;
 }
 
-.dota-main-groups__team-item {
-  line-height: 1.35;
+.dota-main-groups__table {
+  width: 100%;
+  border-collapse: collapse;
+  color: var(--color-text-secondary);
+  font-size: 0.92rem;
+}
+
+.dota-main-groups__table th,
+.dota-main-groups__table td {
+  border: 1px solid color-mix(in srgb, var(--color-border) 82%, transparent);
+  padding: 0.45rem 0.5rem;
+}
+
+.dota-main-groups__table thead th {
+  color: var(--color-text-primary);
+  font-weight: 600;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.dota-main-groups__table tbody th {
+  text-align: left;
+  font-weight: 500;
+}
+
+.dota-main-groups__table tbody td {
+  text-align: center;
 }
 
 @media (max-width: 768px) {

--- a/src/features/DotaMainGroups/DotaMainGroups.jsx
+++ b/src/features/DotaMainGroups/DotaMainGroups.jsx
@@ -3,6 +3,26 @@ import PropTypes from 'prop-types';
 import './DotaMainGroups.css';
 import groupsConfig from './config.json';
 
+const normalizeTeam = (team) => {
+  if (typeof team === 'string') {
+    return {
+      name: team,
+      games: 0,
+      winMaps: 0,
+      loseMaps: 0,
+      points: 0,
+    };
+  }
+
+  return {
+    name: team.name,
+    games: team.games ?? 0,
+    winMaps: team.winMaps ?? 0,
+    loseMaps: team.loseMaps ?? 0,
+    points: team.points ?? 0,
+  };
+};
+
 const DotaMainGroups = ({ data = groupsConfig }) => (
   <section className="dota-main-groups" aria-labelledby="dota-main-groups-title">
     <h4 id="dota-main-groups-title" className="dota-main-groups__title">{data.title}</h4>
@@ -10,16 +30,50 @@ const DotaMainGroups = ({ data = groupsConfig }) => (
       {(data.groups ?? []).map((group) => (
         <article key={group.name} className="dota-main-groups__card" aria-label={group.name}>
           <h5 className="dota-main-groups__group-title">{group.name}</h5>
-          <ul className="dota-main-groups__team-list">
-            {(group.teams ?? []).map((team) => (
-              <li key={`${group.name}-${team}`} className="dota-main-groups__team-item">{team}</li>
-            ))}
-          </ul>
+          <div className="dota-main-groups__table-wrapper">
+            <table className="dota-main-groups__table">
+              <thead>
+                <tr>
+                  <th scope="col">Команда</th>
+                  <th scope="col">Игры</th>
+                  <th scope="col">Win maps</th>
+                  <th scope="col">Lose maps</th>
+                  <th scope="col">Очки</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(group.teams ?? []).map((team) => {
+                  const normalizedTeam = normalizeTeam(team);
+
+                  return (
+                    <tr key={`${group.name}-${normalizedTeam.name}`}>
+                      <th scope="row">{normalizedTeam.name}</th>
+                      <td>{normalizedTeam.games}</td>
+                      <td>{normalizedTeam.winMaps}</td>
+                      <td>{normalizedTeam.loseMaps}</td>
+                      <td>{normalizedTeam.points}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
         </article>
       ))}
     </div>
   </section>
 );
+
+const teamShape = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    games: PropTypes.number,
+    winMaps: PropTypes.number,
+    loseMaps: PropTypes.number,
+    points: PropTypes.number,
+  }),
+]);
 
 DotaMainGroups.propTypes = {
   data: PropTypes.shape({
@@ -27,7 +81,7 @@ DotaMainGroups.propTypes = {
     groups: PropTypes.arrayOf(
       PropTypes.shape({
         name: PropTypes.string.isRequired,
-        teams: PropTypes.arrayOf(PropTypes.string).isRequired,
+        teams: PropTypes.arrayOf(teamShape).isRequired,
       }),
     ),
   }),

--- a/src/features/DotaMainGroups/config.json
+++ b/src/features/DotaMainGroups/config.json
@@ -3,19 +3,39 @@
   "groups": [
     {
       "name": "A группа",
-      "teams": ["Самозванцы", "Japan", "Колбасный Цэх", "Yellow Submarine"]
+      "teams": [
+        { "name": "Самозванцы", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "Japan", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "Колбасный ЦЭХ", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "Yellow Submarine", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 }
+      ]
     },
     {
       "name": "B группа",
-      "teams": ["Podpivas Team", "Mi Ne Pushim", "Buyback Academy", "afk30"]
+      "teams": [
+        { "name": "Pojarniki", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "Mi ne pushim", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "Buyback Academy", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "JazzFive", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 }
+      ]
     },
     {
       "name": "C группа",
-      "teams": ["Tech Titans", "Ягк", "Синергия", "Вифк"]
+      "teams": [
+        { "name": "tech titans", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "ЯГК", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "Синергия", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "ВИФК", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 }
+      ]
     },
     {
       "name": "D группа",
-      "teams": ["Way Prod.", "Гики", "Steel Titans", "Team Borisogleb"]
+      "teams": [
+        { "name": "Way prod.", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "Гики", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "Steel Titans", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 },
+        { "name": "Team Borisogleb", "games": 0, "winMaps": 0, "loseMaps": 0, "points": 0 }
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Обновить состав команд в разделе «Dota 2.Main» согласно переданным A/B/C/D спискам.  
- Показать базовую статистику команд в каждой группе через явные колонки таблицы для прозрачного отображения результатов.

### Description
- Обновлён конфиг групп: `src/features/DotaMainGroups/config.json` — команды приведены к объектам с полями `games`, `winMaps`, `loseMaps`, `points` (начальные `0`).
- Компонент `src/features/DotaMainGroups/DotaMainGroups.jsx` теперь рендерит семантические таблицы с колонками `Игры`, `Win maps`, `Lose maps`, `Очки` и содержит `normalizeTeam` для совместимости со старым форматом строк; также обновлён `propTypes`.
- Добавлены стили табличного вида и адаптивный горизонтальный скролл в `src/features/DotaMainGroups/DotaMainGroups.css`.
- Изменения локализованы в UI-слое и не затрагивают API или зависимости.

### Testing
- Выполнен `npm run lint` — успешно.  
- Выполнен `npm run test` — все тесты прошли (`28 passed`).  
- Выполнен `npm run build` — сборка продакшена успешно завершилась.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d52eccf1a0832796312f65eaf12f49)