### PR TITLE
feat(match-results): добавить отдельный блок «Результаты 1-го тура»

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -3,6 +3,180 @@
   "description": "Следите за динамикой квалификации",
   "rounds": [
     {
+      "id": "round-tour-1",
+      "title": "Результаты 1-го тура",
+      "subtitle": "Групповой этап",
+      "defaultExpanded": true,
+      "weeks": [
+        {
+          "id": "tour-1-week-1",
+          "title": "1-й тур · 25 марта – 6 апреля",
+          "matches": [
+            {
+              "id": "2026-03-27-samozvancy-kolbasny-czech",
+              "dateLabel": "27 мар · 21:00",
+              "dateTime": "2026-03-27T21:00:00+03:00",
+              "stage": "Тур 1 · Группа A",
+              "teams": {
+                "home": "Самозванцы",
+                "away": "Колбасный ЦЭХ"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-27-samozvancy-kolbasny-czech",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-03-26-japan-yellow-submarine",
+              "dateLabel": "26 мар · 20:00",
+              "dateTime": "2026-03-26T20:00:00+03:00",
+              "stage": "Тур 1 · Группа A",
+              "teams": {
+                "home": "Japan 日本",
+                "away": "Yellow Submarine"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-26-japan-yellow-submarine",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-04-06-jazzfive-mi-ne-pushim",
+              "dateLabel": "6 апр · 18:00",
+              "dateTime": "2026-04-06T18:00:00+03:00",
+              "stage": "Тур 1 · Группа B",
+              "teams": {
+                "home": "jazzfive",
+                "away": "Mi ne Pushim!"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-06-jazzfive-mi-ne-pushim",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-04-05-pojarniki-buyback-academy",
+              "dateLabel": "5 апр · 19:00",
+              "dateTime": "2026-04-05T19:00:00+03:00",
+              "stage": "Тур 1 · Группа B",
+              "teams": {
+                "home": "pojarniki",
+                "away": "Buyback Academy"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-05-pojarniki-buyback-academy",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-03-28-tech-titans-vifk",
+              "dateLabel": "28 мар · 09:00",
+              "dateTime": "2026-03-28T09:00:00+03:00",
+              "stage": "Тур 1 · Группа C",
+              "teams": {
+                "home": "Tech Titans",
+                "away": "ВИФК"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-28-tech-titans-vifk",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-03-25-yagk-synergia-sr",
+              "dateLabel": "25 мар · 21:00",
+              "dateTime": "2026-03-25T21:00:00+03:00",
+              "stage": "Тур 1 · Группа C",
+              "teams": {
+                "home": "ЯГК",
+                "away": "Синергия ср"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-25-yagk-synergia-sr",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-03-27-way-prod-giki",
+              "dateLabel": "27 мар · 21:00",
+              "dateTime": "2026-03-27T21:00:00+03:00",
+              "stage": "Тур 1 · Группа D",
+              "teams": {
+                "home": "Way Prod.",
+                "away": "Гики"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-27-way-prod-giki",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-03-27-steel-titans-team-borisogleb",
+              "dateLabel": "27 мар · 20:00",
+              "dateTime": "2026-03-27T20:00:00+03:00",
+              "stage": "Тур 1 · Группа D",
+              "teams": {
+                "home": "Steel Titans",
+                "away": "Team Borisogleb"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-27-steel-titans-team-borisogleb",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "round-1",
       "title": "Результаты 1-го круга",
       "subtitle": "Групповой этап",

--- a/src/features/QualificationsTable/standings.test.js
+++ b/src/features/QualificationsTable/standings.test.js
@@ -24,17 +24,17 @@ test('buildStandingsFromMatchResults aggregates finished matches into standings'
   assert.deepStrictEqual(miNePushim, {
     id: 'mi-ne-pushim',
     name: 'Mi ne Pushim!',
-    matches: 4,
-    wins: 2,
+    matches: 5,
+    wins: 3,
     losses: 2,
-    mapWins: 6,
+    mapWins: 8,
     mapLosses: 4,
-    points: 6,
+    points: 8,
   });
 
   const uniqueIds = new Set(standings.map((team) => team.id));
   assert.strictEqual(standings.length, uniqueIds.size);
-  assert.strictEqual(standings.length, 14);
+  assert.strictEqual(standings.length, 21);
 });
 
 test('buildStandingsFromMatches aggregates matches for a single week', () => {


### PR DESCRIPTION
### Motivation
- Необходимо вынести результаты 1-го тура в отдельный блок в том же формате, что и существующие блоки результатов.  
- Избежать дублирования идентификаторов/несовпадения названий команд при агрегировании таблиц.  
- Обновить тестовые ожидания, чтобы они отражали новую входную конфигурацию матчей.

### Description
- Добавлен новый блок `Результаты 1-го тура` в `src/features/MatchResults/config.json` с одним `week` и 8 матчами по группам A/B/C/D в формате, совпадающем с существующими блоками.  
- Нормализованы названия команд в новом блоке (например, `Mi ne Pushim!`, `Yellow Submarine`, `Tech Titans`, `Way Prod.`) чтобы не создавать дубликатных ID при агрегировании стоек.  
- Обновлены ожидания в `src/features/QualificationsTable/standings.test.js` под изменившиеся агрегированные значения (статистика команды `Mi ne Pushim!` и общее число команд в таблице).

### Testing
- Запущены `npm run lint` — пройдено без ошибок.  
- Запущены `npm run test` — все тесты успешно прошли после правок (локальная прогонка закончилась успешно).  
- Запущена сборка `npm run build` — сборка прошла успешно без ошибок.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d532f09d288327842a9fdc74cac691)