### PR TITLE
Update MatchResults dataset and adjust standings tests for new fixtures

### DIFF
--- a/src/features/MatchResults/config.json
+++ b/src/features/MatchResults/config.json
@@ -171,6 +171,306 @@
               "detailsUrl": "https://example.com/dota-2026-03-27-steel-titans-team-borisogleb",
               "detailsLabel": "Смотреть повтор",
               "winner": "away"
+            },
+            {
+              "id": "2026-04-01-samozvancy-japan",
+              "dateLabel": "1 апр · 21:30",
+              "dateTime": "2026-04-01T21:30:00+03:00",
+              "stage": "Тур 2 · Группа A",
+              "teams": {
+                "home": "Самозванцы",
+                "away": "Japan 日本"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-01-samozvancy-japan",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-03-29-kolbasny-czech-yellow-submarine",
+              "dateLabel": "29 мар · 21:00",
+              "dateTime": "2026-03-29T21:00:00+03:00",
+              "stage": "Тур 2 · Группа A",
+              "teams": {
+                "home": "Колбасный ЦЭХ",
+                "away": "Yellow Submarine"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-29-kolbasny-czech-yellow-submarine",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-03-31-mi-ne-pushim-buyback-academy",
+              "dateLabel": "31 мар · 19:00",
+              "dateTime": "2026-03-31T19:00:00+03:00",
+              "stage": "Тур 2 · Группа B",
+              "teams": {
+                "home": "Mi ne Pushim!",
+                "away": "Buyback Academy"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-31-mi-ne-pushim-buyback-academy",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-03-30-tech-titans-ygk",
+              "dateLabel": "30 мар · 19:00",
+              "dateTime": "2026-03-30T19:00:00+03:00",
+              "stage": "Тур 2 · Группа C",
+              "teams": {
+                "home": "Tech Titans",
+                "away": "ЯГК"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-30-tech-titans-ygk",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-03-30-vifk-synergia",
+              "dateLabel": "30 мар · 20:00",
+              "dateTime": "2026-03-30T20:00:00+03:00",
+              "stage": "Тур 2 · Группа C",
+              "teams": {
+                "home": "ВИФК",
+                "away": "Синергия"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-30-vifk-synergia",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-03-29-team-borisogleb-giki",
+              "dateLabel": "29 мар · 18:00",
+              "dateTime": "2026-03-29T18:00:00+03:00",
+              "stage": "Тур 2 · Группа D",
+              "teams": {
+                "home": "Team Borisogleb",
+                "away": "Гики"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-29-team-borisogleb-giki",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-03-31-steel-titans-way-prod",
+              "dateLabel": "31 мар · 21:00",
+              "dateTime": "2026-03-31T21:00:00+03:00",
+              "stage": "Тур 2 · Группа D",
+              "teams": {
+                "home": "Steel Titans",
+                "away": "Way Prod."
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-03-31-steel-titans-way-prod",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-04-05-samozvancy-yellow-submarine",
+              "dateLabel": "5 апр · 19:00",
+              "dateTime": "2026-04-05T19:00:00+03:00",
+              "stage": "Тур 3 · Группа A",
+              "teams": {
+                "home": "Самозванцы",
+                "away": "Yellow Submarine"
+              },
+              "score": {
+                "home": 1,
+                "away": 1
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "1–1 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-05-samozvancy-yellow-submarine",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-04-04-kolbasny-czech-japan",
+              "dateLabel": "4 апр · 16:00",
+              "dateTime": "2026-04-04T16:00:00+03:00",
+              "stage": "Тур 3 · Группа A",
+              "teams": {
+                "home": "Колбасный ЦЭХ",
+                "away": "Japan 日本"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-04-kolbasny-czech-japan",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-04-05-pojarniki-buyback-academy-tour3",
+              "dateLabel": "5 апр · 18:00",
+              "dateTime": "2026-04-05T18:00:00+03:00",
+              "stage": "Тур 3 · Группа B",
+              "teams": {
+                "home": "pojarniki",
+                "away": "Buyback Academy"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-05-pojarniki-buyback-academy-tour3",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-04-05-mi-ne-pushim-jazzfive",
+              "dateLabel": "5 апр · 18:00",
+              "dateTime": "2026-04-05T18:00:00+03:00",
+              "stage": "Тур 3 · Группа B",
+              "teams": {
+                "home": "Mi ne Pushim!",
+                "away": "jazzfive"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-05-mi-ne-pushim-jazzfive",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-04-06-tech-titans-synergia",
+              "dateLabel": "6 апр · 18:00",
+              "dateTime": "2026-04-06T18:00:00+03:00",
+              "stage": "Тур 3 · Группа C",
+              "teams": {
+                "home": "Tech Titans",
+                "away": "Синергия"
+              },
+              "score": {
+                "home": 2,
+                "away": 0
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "2–0 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-06-tech-titans-synergia",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "home"
+            },
+            {
+              "id": "2026-04-06-vifk-ygk",
+              "dateLabel": "6 апр · 18:00",
+              "dateTime": "2026-04-06T18:00:00+03:00",
+              "stage": "Тур 3 · Группа C",
+              "teams": {
+                "home": "ВИФК",
+                "away": "ЯГК"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-06-vifk-ygk",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-04-04-team-borisogleb-way-prod",
+              "dateLabel": "4 апр · 21:00",
+              "dateTime": "2026-04-04T21:00:00+03:00",
+              "stage": "Тур 3 · Группа D",
+              "teams": {
+                "home": "Team Borisogleb",
+                "away": "Way Prod."
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-04-team-borisogleb-way-prod",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
+            },
+            {
+              "id": "2026-04-06-steel-titans-giki",
+              "dateLabel": "6 апр · 18:00",
+              "dateTime": "2026-04-06T18:00:00+03:00",
+              "stage": "Тур 3 · Группа D",
+              "teams": {
+                "home": "Steel Titans",
+                "away": "Гики"
+              },
+              "score": {
+                "home": 0,
+                "away": 2
+              },
+              "bestOf": 3,
+              "status": "finished",
+              "statusLabel": "0–2 · завершён",
+              "detailsUrl": "https://example.com/dota-2026-04-06-steel-titans-giki",
+              "detailsLabel": "Смотреть повтор",
+              "winner": "away"
             }
           ]
         }

--- a/src/features/QualificationsTable/standings.test.js
+++ b/src/features/QualificationsTable/standings.test.js
@@ -24,17 +24,17 @@ test('buildStandingsFromMatchResults aggregates finished matches into standings'
   assert.deepStrictEqual(miNePushim, {
     id: 'mi-ne-pushim',
     name: 'Mi ne Pushim!',
-    matches: 5,
-    wins: 3,
+    matches: 7,
+    wins: 5,
     losses: 2,
-    mapWins: 8,
+    mapWins: 12,
     mapLosses: 4,
-    points: 8,
+    points: 12,
   });
 
   const uniqueIds = new Set(standings.map((team) => team.id));
   assert.strictEqual(standings.length, uniqueIds.size);
-  assert.strictEqual(standings.length, 21);
+  assert.strictEqual(standings.length, 22);
 });
 
 test('buildStandingsFromMatches aggregates matches for a single week', () => {
@@ -42,8 +42,8 @@ test('buildStandingsFromMatches aggregates matches for a single week', () => {
   const standings = buildStandingsFromMatches(firstFinishedWeek.matches);
 
   const firstTeam = standings.find((team) => team.name === 'Mi ne Pushim!');
-  assert.strictEqual(firstTeam.points, 2);
-  assert.strictEqual(firstTeam.matches, 1);
+  assert.strictEqual(firstTeam.points, 6);
+  assert.strictEqual(firstTeam.matches, 3);
 });
 
 test('buildStandingsFromMatchResults applies point deductions for penalized teams', () => {


### PR DESCRIPTION
### Motivation
- Add newly finished matches and upcoming fixtures into the `MatchResults` dataset to reflect March–April 2026 results and rounds. 
- Ensure the qualifications standings tests reflect the expanded dataset and updated aggregate values produced from the new matches. 

### Description
- Added many new match entries to `src/features/MatchResults/config.json` (additional fixtures in late March and early April 2026 across Groups A–D). 
- Updated expected aggregated standings in `src/features/QualificationsTable/standings.test.js`, adjusting `Mi ne Pushim!` stats (`matches`, `wins`, `mapWins`, `points`) and the total number of teams from `21` to `22`. 
- Adjusted the single-week aggregation assertions in `standings.test.js` to match the new first-week aggregated totals (`points` and `matches`).

### Testing
- Ran the unit test suite with `vitest`, which executed the updated `standings.test.js` assertions. 
- All automated tests that were run passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d535c381e88327bef786c976c3465b)