### PR TITLE
Filter Dota match results per discipline and wire into App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,8 @@ import UpcomingMatches from './features/UpcomingMatches/UpcomingMatches.jsx';
 import upcomingMatchesConfig from './features/UpcomingMatches/config.json';
 import MatchResults from './features/MatchResults/MatchResults.jsx';
 import matchResultsConfig from './features/MatchResults/config.json';
+import dotaMainMatchResultsConfig from './features/MatchResults/dota-main-config.js';
+import dotaQualMatchResultsConfig from './features/MatchResults/dota-qual-config.js';
 import cs2MatchResultsConfig from './features/MatchResults/cs2-config.json';
 import registrationCtaConfig from './features/RegistrationCta/config.json';
 import sponsorsConfig from './features/Sponsors/config.json';
@@ -36,6 +38,8 @@ const App = () => {
   }, []);
 
   const THEME_STORAGE_KEY = 'ycs-theme';
+
+
 
   const getInitialTheme = useCallback(() => {
     if (typeof window === 'undefined') {
@@ -173,6 +177,7 @@ const App = () => {
           >
             <GameDisciplineSection id="dota-2-main" title="Dota 2.Main" isExpanded isCollapsible={false}>
               <DotaMainGroups />
+              <MatchResults data={dotaMainMatchResultsConfig} />
             </GameDisciplineSection>
           </div>
 
@@ -185,7 +190,7 @@ const App = () => {
             <GameDisciplineSection id="dota-2-qual" title="DotA 2.Qual" isExpanded isCollapsible={false}>
               <TeamShowcase />
               <QualificationsTable data={qualificationsConfig} matchResults={matchResultsConfig} />
-              <MatchResults data={matchResultsConfig} />
+              <MatchResults data={dotaQualMatchResultsConfig} />
             </GameDisciplineSection>
           </div>
 

--- a/src/features/MatchResults/dota-main-config.js
+++ b/src/features/MatchResults/dota-main-config.js
@@ -1,0 +1,15 @@
+import dotaMatchResultsConfig from './config.json';
+
+const DOTA_MAIN_ROUNDS = new Set([
+  'Результаты 1-го тура',
+  'Результаты 1-го круга',
+  'Результаты 2-го круга',
+  'Результаты 3-го круга',
+]);
+
+const dotaMainMatchResultsConfig = {
+  ...dotaMatchResultsConfig,
+  rounds: dotaMatchResultsConfig.rounds.filter((round) => DOTA_MAIN_ROUNDS.has(round.title)),
+};
+
+export default dotaMainMatchResultsConfig;

--- a/src/features/MatchResults/dota-qual-config.js
+++ b/src/features/MatchResults/dota-qual-config.js
@@ -1,0 +1,8 @@
+import dotaMatchResultsConfig from './config.json';
+
+const dotaQualMatchResultsConfig = {
+  ...dotaMatchResultsConfig,
+  rounds: dotaMatchResultsConfig.rounds.filter((round) => round.title !== 'Результаты 1-го круга'),
+};
+
+export default dotaQualMatchResultsConfig;


### PR DESCRIPTION
### Motivation
- Provide discipline-specific match results for Dota 2 main and qualifiers by filtering the shared match results dataset.
- Ensure the Dota 2 Main panel shows only main-round results and the Dota 2 Qual panel excludes the first round where applicable.

### Description
- Add `dota-main-config.js` which imports `./config.json` and filters `rounds` to only include the main rounds defined in `DOTA_MAIN_ROUNDS`.
- Add `dota-qual-config.js` which imports `./config.json` and filters `rounds` to exclude the "Результаты 1-го круга" round.
- Import the two new configs in `src/App.jsx` and pass `dotaMainMatchResultsConfig` to the Dota 2 Main `MatchResults` and `dotaQualMatchResultsConfig` to the Dota 2 Qual `MatchResults`.
- Minor whitespace/import adjustments in `src/App.jsx` to integrate the new modules.

### Testing
- Ran the application build with `npm run build` and the build completed successfully.
- Executed the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d53848d1448327a39177cf8ab9475c)